### PR TITLE
修复角色菜单半选中时，菜单不展示的问题

### DIFF
--- a/src/views/admin/sys-role/index.vue
+++ b/src/views/admin/sys-role/index.vue
@@ -378,13 +378,13 @@ export default {
     // 所有菜单节点数据
     getMenuAllCheckedKeys() {
       // 目前被选中的菜单节点
-      const checkedKeys = this.$refs.menuTree.getHalfCheckedKeys()
+      const checkedKeys = this.$refs.menuTree.getCheckedKeys()
       console.log('目前被选中的菜单节点', checkedKeys)
       // 半选中的菜单节点
-      const halfCheckedKeys = this.$refs.menuTree.getCheckedKeys()
+      const halfCheckedKeys = this.$refs.menuTree.getHalfCheckedKeys()
       console.log('半选中的菜单节点', halfCheckedKeys)
-      // checkedKeys.unshift.apply(checkedKeys, halfCheckedKeys)
-      return halfCheckedKeys
+      checkedKeys.unshift.apply(checkedKeys, halfCheckedKeys)
+      return checkedKeys
     },
     // 所有部门节点数据
     getDeptAllCheckedKeys() {
@@ -402,9 +402,22 @@ export default {
         this.menuOptions = []
       } else {
         this.$nextTick(() => {
-          this.$refs.menuTree.setCheckedKeys(checkedKeys)
+          this.setMenuCheckedKeys(checkedKeys)
         })
       }
+    },
+    /** 回显菜单树，仅设置叶子节点的选中状态 */
+    setMenuCheckedKeys(val) {
+      this.$refs.menuTree.setCheckedKeys([])
+      this.$nextTick(() => {
+        const that = this
+        val.forEach((i, n) => {
+          const node = that.$refs.menuTree.getNode(i)
+          if (node.isLeaf) {
+            that.$refs.menuTree.setChecked(node, true)
+          }
+        })
+      })
     },
     /** 根据角色ID查询部门树结构 */
     getRoleDeptTreeselect(roleId) {


### PR DESCRIPTION
问题描述：角色菜单编辑时仅上传勾选状态的菜单，避免了回显时菜单树中半勾选项的显示错误问题，但用户的菜单渲染未做特色处理，导致半勾选的菜单无法显示，进而其下的子菜单也不能显示。

解决方案：角色菜单编辑时上传**半勾选+勾选状态**的菜单，回显时做特殊处理-**仅设置叶子节点的选中状态**，用户的菜单渲染逻辑不变。
