### PR TITLE
升级 echarts 至 6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "core-js": "^3.50.0",
     "driver.js": "0.9.8",
     "dropzone": "5.9.3",
-    "echarts": "^5.6.0",
+    "echarts": "^6.1.0",
     "element-plus": "^2.14.4",
     "file-saver": "2.0.5",
     "fuse.js": "6.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       echarts:
-        specifier: ^5.6.0
-        version: 5.6.0
+        specifier: ^6.1.0
+        version: 6.1.0
       element-plus:
         specifier: ^2.14.4
         version: 2.14.4(vue@3.5.41)
@@ -3066,8 +3066,8 @@ packages:
     resolution: {integrity: sha512-wK2sCs4feiiJeFXn3zvY0p41mdU5VUgbgs1rNsc/y5ngFUijdWd+iIN8eoyuZHKB8xN6BL4PdWmzqFmxNg6V2w==}
     engines: {node: '>=6.0.0'}
 
-  echarts@5.6.0:
-    resolution: {integrity: sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==}
+  echarts@6.1.0:
+    resolution: {integrity: sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==}
 
   editorconfig@1.0.7:
     resolution: {integrity: sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==}
@@ -6997,8 +6997,8 @@ packages:
     resolution: {integrity: sha512-jcKpkthap6x63MB4TxwCyuIGkV0oYP/YRyuQU5UO0Yz/E/ZAu+653/uov+phdmO54n6BcvFRyyt0RRrWdN2mpw==}
     engines: {node: '>=4'}
 
-  zrender@5.6.1:
-    resolution: {integrity: sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==}
+  zrender@6.1.0:
+    resolution: {integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==}
 
 snapshots:
 
@@ -10527,10 +10527,10 @@ snapshots:
 
   easy-stack@1.0.1: {}
 
-  echarts@5.6.0:
+  echarts@6.1.0:
     dependencies:
       tslib: 2.3.0
-      zrender: 5.6.1
+      zrender: 6.1.0
 
   editorconfig@1.0.7:
     dependencies:
@@ -15122,6 +15122,6 @@ snapshots:
       normalize-path: 1.0.0
       strip-indent: 2.0.0
 
-  zrender@5.6.1:
+  zrender@6.1.0:
     dependencies:
       tslib: 2.3.0


### PR DESCRIPTION
将 echarts 由 5.6.0 升级至 6.1.0，修复 2 条 Dependabot 安全告警（medium）。

## 兼容性

项目仅使用 `echarts.init`（10 处）与 `echarts.graphic`（4 处，用于渐变），图表类型为 bar / line / pie / radar。这些 API 在 ECharts 6 中均保持兼容，**业务代码无需任何改动**。

## ⚠️ 视觉变更

ECharts 6 变更了默认主题，以下方面会与升级前不同：

- 图表配色
- legend 默认位置（移至底部）
- 坐标轴布局（新的溢出防护机制默认启用，轴位置可能轻微偏移）

影响范围为 Dashboard 首页图表及 `Bar` / `MiniArea` / `MiniBar` / `Keyboard` / `MixChart` / `LineMarker` 等共 10 处组件。

如需恢复 v5 视觉，可引入 `echarts/theme/v5` 并在 `echarts.init(dom, 'v5')` 时指定主题。

## 收益

构建产物 `chunk-libs` 由 2844 KiB 减至 2516 KiB（-328 KiB）。

## 验证

- 单元测试：29 / 29 通过
- ESLint：0 error
- 生产构建：成功
