### PR TITLE
版本号更新至 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-admin",
-  "version": "2.0.9",
+  "version": "3.0.0",
   "description": "A magical vue admin. An out-of-box UI solution for enterprise applications. Newest development stack of vue. Lots of awesome features",
   "author": "https://github.com/wenjianzhang",
   "license": "MIT",


### PR DESCRIPTION
为发布 v3.0.0 更新 package.json 版本号。

上一个版本 v2.0.9 发布于 2022-02，此后累计 163 个提交，包含 Vue 2→3、Element UI→Element Plus、Vue CLI→Vite、Node 8.9→22 等破坏性变更，按语义化版本进入 major。

详细变更见 Release notes。