### PR TITLE
fix🐛: 修正 parseTime 类型错误与二级菜单缓存失效

### DIFF
--- a/src/layout/components/AppMain.vue
+++ b/src/layout/components/AppMain.vue
@@ -1,26 +1,16 @@
 <template>
   <section class="app-main" :style="appMainStyle">
-    <!-- Vue Router 4 起 router-view 不能直接置于 transition / keep-alive 内：
-         keep-alive 收到的子节点是 RouterView 组件本身而非页面组件，include
-         按组件名匹配因而永不命中，缓存实际处于失效状态。改用 v-slot 取出已
-         匹配的组件再交给 keep-alive。 -->
-    <router-view v-slot="{ Component, route }">
-      <transition name="fade-transform" mode="out-in">
-        <keep-alive :include="cachedViews">
-          <component :is="Component" :key="route.path" />
-        </keep-alive>
-      </transition>
-    </router-view>
+    <router-view-keep-alive transition="fade-transform" />
   </section>
 </template>
 
 <script>
+import RouterViewKeepAlive from './RouterViewKeepAlive'
+
 export default {
   name: 'AppMain',
+  components: { RouterViewKeepAlive },
   computed: {
-    cachedViews() {
-      return this.$store.state.tagsView.cachedViews
-    },
     appMainStyle() {
       if (!this.$store.state.settings.fixedHeader) return {}
       const headerHeight = 50 + (this.$store.state.settings.tagsView ? 40 : 0)

--- a/src/layout/components/RouterViewKeepAlive.vue
+++ b/src/layout/components/RouterViewKeepAlive.vue
@@ -1,0 +1,37 @@
+<template>
+  <!--
+    带缓存的 router-view。
+
+    keep-alive 的 include 按组件 name 匹配，而 cachedViews 里存的是叶子路由的
+    name。若某一层只写裸 <router-view />，该层渲染出的是下一级组件，它自己不受
+    keep-alive 管辖，叶子页每次进入都会重建 —— 二级菜单（Layout > 容器 > 叶子）
+    的缓存正是这样失效的。
+
+    因此凡是承载子路由的位置都应使用本组件，而非裸 router-view。
+  -->
+  <router-view v-slot="{ Component, route }">
+    <transition :name="transition" mode="out-in">
+      <keep-alive :include="cachedViews">
+        <component :is="Component" :key="route.path" />
+      </keep-alive>
+    </transition>
+  </router-view>
+</template>
+
+<script>
+export default {
+  name: 'RouterViewKeepAlive',
+  props: {
+    // 容器层不需要再播一次过渡，否则同一次导航会叠加两段动画
+    transition: {
+      type: String,
+      default: ''
+    }
+  },
+  computed: {
+    cachedViews() {
+      return this.$store.state.tagsView.cachedViews
+    }
+  }
+}
+</script>

--- a/src/utils/costum.js
+++ b/src/utils/costum.js
@@ -4,7 +4,9 @@ export function parseTime(time, pattern) {
   if (arguments.length === 0 || !time) {
     return null
   }
-  if (time.indexOf('01-01-01') > -1) {
+  // 仅字符串才有 indexOf：入参也可能是时间戳数字或 Date 对象，
+  // 无条件调用会抛 TypeError: time.indexOf is not a function
+  if (typeof time === 'string' && time.indexOf('01-01-01') > -1) {
     return '-'
   }
   const format = pattern || '{y}-{m}-{d} {h}:{i}:{s}'

--- a/src/views/log/index.vue
+++ b/src/views/log/index.vue
@@ -1,9 +1,17 @@
 <template>
-  <router-view />
+  <!--
+    承载子路由的容器。此前是裸 <router-view />，其渲染出的叶子页不受任何
+    keep-alive 管辖，导致「日志管理」下的登录日志、操作日志每次进入都被重建，
+    搜索条件与分页位置全部丢失。
+  -->
+  <router-view-keep-alive />
 </template>
 
 <script>
+import RouterViewKeepAlive from '@/layout/components/RouterViewKeepAlive'
+
 export default {
-  name: 'LogContainer'
+  name: 'Log',
+  components: { RouterViewKeepAlive }
 }
 </script>

--- a/tests/unit/utils/costumParseTime.spec.js
+++ b/tests/unit/utils/costumParseTime.spec.js
@@ -1,0 +1,46 @@
+import { parseTime } from '@/utils/costum.js'
+
+// costum.js 的 parseTime 才是全局 $parseTime 的实现，此前无任何测试覆盖。
+// 它比 utils/index.js 的同名函数多一段哨兵判断：后端对零值时间返回
+// "0001-01-01 00:00:00"，需显示为 "-"。该判断曾无条件调用 time.indexOf，
+// 导致数字时间戳与 Date 对象入参直接抛 TypeError。
+describe('Utils:costum parseTime', () => {
+  it('格式化字符串日期', () => {
+    expect(parseTime('2026-01-01 10:00:00')).toBe('2026-01-01 10:00:00')
+  })
+
+  it('格式化 Date 对象', () => {
+    expect(parseTime(new Date('2026-01-01 10:00:00'))).toBe('2026-01-01 10:00:00')
+  })
+
+  it('格式化秒级时间戳', () => {
+    const sec = Math.floor(new Date('2026-01-01 10:00:00').getTime() / 1000)
+    expect(parseTime(sec)).toBe('2026-01-01 10:00:00')
+  })
+
+  it('格式化毫秒级时间戳', () => {
+    const ms = new Date('2026-01-01 10:00:00').getTime()
+    expect(parseTime(ms)).toBe('2026-01-01 10:00:00')
+  })
+
+  it('后端零值时间显示为短横线', () => {
+    expect(parseTime('0001-01-01 00:00:00')).toBe('-')
+  })
+
+  it('自定义格式（个位数补零）', () => {
+    expect(parseTime('2026-01-01 10:00:00', '{y}/{m}/{d}')).toBe('2026/01/01')
+  })
+
+  it('空值返回 null', () => {
+    expect(parseTime(null)).toBeNull()
+    expect(parseTime('')).toBeNull()
+    expect(parseTime()).toBeNull()
+  })
+
+  // 回归用例：把哨兵判断改回无条件的 time.indexOf 会让下面三条全部抛错
+  it('非字符串入参不抛异常', () => {
+    expect(() => parseTime(1735689600)).not.toThrow()
+    expect(() => parseTime(1735689600000)).not.toThrow()
+    expect(() => parseTime(new Date())).not.toThrow()
+  })
+})


### PR DESCRIPTION
修复 issue 扫描中确认仍然成立的两个缺陷。两处均补充了实测与反向验证。

## 1. parseTime 对非字符串入参抛 TypeError（#161）

`src/utils/costum.js` 的 `parseTime` 才是全局 `$parseTime` 的实现。它比 `utils/index.js` 的同名函数多一段哨兵判断——后端对零值时间返回 `"0001-01-01 00:00:00"`，需显示为短横线——但该判断无条件调用了 `time.indexOf`：

```js
if (time.indexOf('01-01-01') > -1) {
```

而入参也可能是时间戳数字或 `Date` 对象，二者均无 `indexOf`。实测：

| 入参 | 修复前 | 修复后 |
|---|---|---|
| 秒级时间戳 `1735689600` | ❌ `TypeError: time.indexOf is not a function` | ✅ |
| 毫秒级时间戳 | ❌ 同上 | ✅ |
| `Date` 对象 | ❌ 同上 | ✅ |
| 字符串日期 | ✅ | ✅ |
| 哨兵值 `0001-01-01 00:00:00` | ✅ `-` | ✅ `-` |

三种入参中有两种完全不可用。将判断限定为字符串入参即可。

该函数此前**无任何测试覆盖**（现有 `parseTime.spec.js` 测的是 `utils/index.js` 的另一份实现），本 PR 补充 8 项回归测试。反向验证：还原此处判断会使其中 4 个用例失败。

## 2. 二级菜单页面 keep-alive 缓存失效（#212）

先前的修复只覆盖了一级路由。当菜单配置中存在容器层——某级菜单的 `component` 不是 `Layout` 而是一个自身承载子路由的页面——组件链会变成三层：

```
/admin/sys-oper-log  →  [Admin(Layout), Log(容器), OperLog(叶子)]
```

`AppMain` 的 keep-alive 拿到的是容器组件 `Log`，而 `cachedViews` 中存放的是叶子路由名 `OperLog`，`include` 因此匹配不到；容器 `views/log/index.vue` 内又只是一个裸 `router-view`，其渲染出的叶子页不受任何 keep-alive 管辖。

结果是「日志管理」下的登录日志与操作日志每次进入都被重建，搜索条件与分页位置丢失。

将带缓存的 router-view 抽为 `RouterViewKeepAlive` 组件，`AppMain` 与容器组件共用，任意层级均可命中。容器层不再重复播放过渡动画，避免同一次导航叠加两段动效。

### 实测

| 路由层级 | 页面 | 修复前 | 修复后 |
|---|---|---|---|
| 一级 | 用户管理 / 接口管理 | ✅ | ✅ |
| 二级 | 登录日志 / 操作日志 | ❌ | ✅ |

反向验证：将容器改回裸 `router-view` 后，二级路由缓存立即失效；改回本 PR 的写法后恢复。

## 验证

- ESLint 0 error
- 单元测试 37 项全部通过（新增 8 项）
- 生产构建成功
