### PR TITLE
fix🐛: 修正刷新 token 接口的路径与方法

### DIFF
--- a/src/api/user.js
+++ b/src/api/user.js
@@ -18,11 +18,12 @@ export function logout() {
 }
 
 // refreshtoken 刷新token
-export function refreshtoken(data) {
+// 后端路由为 GET /api/v1/refresh_token（app/admin/router/sys_router.go），
+// 此处此前写的是 POST /refreshtoken，路径与方法均不匹配，调用必然 404
+export function refreshtoken() {
   return request({
-    url: '/refreshtoken',
-    method: 'post',
-    data
+    url: '/api/v1/refresh_token',
+    method: 'get'
   })
 }
 


### PR DESCRIPTION
## 问题

前端调用的是 `POST /refreshtoken`，而后端路由为 `GET /api/v1/refresh_token`（`app/admin/router/sys_router.go:73`），**路径与方法均不匹配**，调用必然 404。

改为与后端一致。原先传入的 `{ token: state.token }` 一并去掉——刷新凭据取自 `Authorization` 头，由请求拦截器统一注入，无需再放进请求体。

该接口对应的 store action（`store/modules/user.js:99`）目前全项目无调用方，修正后可作为后续接入 token 续期的基础。

## 与社区 PR 的关系

go-admin PR #828 提议将后端方法改为 POST。但前端路径同样不匹配，仅改后端不足以修复；且后端现有路由已登记在 `CasbinExclude` 白名单中，改动它需同步调整白名单。故统一以后端现有路由为准。

## 相关但未处理的上游缺陷

issue #820 指出业务 token 可无限续期。核实确认：`go-admin-core` 的 `RefreshToken` 会把 `orig_iat` 重置为当前时间，而 `CheckIfTokenExpire` 正是依据 `orig_iat` 与 `MaxRefresh` 判断能否刷新，二者相互抵消，`MaxRefresh = 1h` 形同虚设。该逻辑位于依赖仓库 `sdk/pkg/jwtauth/jwtauth.go`，最新的 `v1.6.6` 仍未修复，需在上游解决。

**在上游修复前，本次改动不会启用自动续期**——action 仍无调用方，不会扩大该缺陷的暴露面。

## 验证

- ESLint 0 error
- 单元测试 49 项全部通过
- 生产构建成功
