### PR TITLE
feat✨: 新增 crud mixin、demo 参照页面与 AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,145 @@
+# AGENTS.md — go-admin-ui 前端
+
+> 给 AI 编码工具与新贡献者的约定。**只写"不遵守就会出错"的规则**；依赖版本以
+> `package.json` 为准，命令以其 `scripts` 为准，此处不复述，避免与代码脱节。
+>
+> 标准列表页的完整写法见 **`src/views/demo/`** —— 那是可构建、有测试、CI 会跑的
+> 参照物。本文与它冲突时，以它为准。
+
+## 页面结构
+
+业务页面统一由 `BasicLayout` 包裹，内容放 `#wrapper` 插槽：
+
+```vue
+<template>
+  <BasicLayout>
+    <template #wrapper>
+      <el-card class="box-card">
+        <!-- 搜索表单 → 操作按钮 → el-table → AppPagination -->
+      </el-card>
+    </template>
+  </BasicLayout>
+</template>
+```
+
+**组件 `name` 必须与后端菜单配置的 `menu_name` 一致** —— `keep-alive` 的 `include`
+按组件名匹配，而缓存名单存的是路由名。不一致时缓存会静默失效，没有任何报错。
+（`loadView` 已做运行时兜底，但源码仍应保持一致，便于排查。）
+
+## 列表页优先使用 crud mixin
+
+分页查询、搜索重置、多选、新增/修改弹窗、删除确认这几段逻辑在各页面实现完全
+相同，已收敛到 `@/mixins/crud`。页面只需声明差异部分：
+
+```js
+import crud from '@/mixins/crud'
+
+export default {
+  name: 'DemoProduct',        // 必须与后端菜单的 menu_name 一致
+  mixins: [crud],
+  created() { this.getList() },
+  methods: {
+    crudOptions() {
+      return {
+        idKey: 'id',
+        api: { list, get, add, update, del },
+        defaultForm: () => ({ id: undefined, name: undefined })
+      }
+    }
+  }
+}
+```
+
+mixin 提供 `list` `total` `loading` `ids` `single` `multiple` `open` `title`
+`form` `queryParams` 等状态，以及 `getList` `handleQuery` `resetQuery`
+`handleSelectionChange` `handleAdd` `handleUpdate` `handleDelete` `cancel`
+`submitForm` 等方法，页面中直接使用，不要重复实现。
+
+完整示例见 `src/views/demo/product/index.vue`。
+
+## API 层
+
+按模块放在 `src/api/`，统一走 `@/utils/request`：
+
+| 操作 | 函数名 | 方法 |
+|---|---|---|
+| 列表 | `list{Resource}` | GET |
+| 详情 | `get{Resource}` | GET |
+| 新增 | `add{Resource}` | POST |
+| 修改 | `update{Resource}` | PUT |
+| 删除 | `del{Resource}` | DELETE |
+
+响应结构为 `{ code, data, msg }`，`code === 200` 为成功。拦截器已统一处理
+401/403 与错误提示，业务代码只需判断 `code`。
+
+**上传文件必须传 `FormData`** —— 拦截器会据此跳过 `Content-Type`，交由浏览器写入
+带 boundary 的 `multipart/form-data`。手工设置该头会导致文件被序列化成 JSON 丢失。
+
+## 权限
+
+```vue
+<el-button v-permisaction="['admin:sysPost:add']">新增</el-button>
+```
+
+标识格式 `模块:资源:操作`，需与后端 `sys_menu` 中的配置一致。
+角色级控制用 `v-permission="['admin']"`。
+
+## 路由
+
+页面路由由后端菜单动态生成（`store/modules/permission.js`），前端只维护
+`router/index.js` 中的固定路由（登录、首页、错误页等）。
+
+`meta` 字段：`title` `icon` `noCache` `affix` `hidden` `breadcrumb`。
+
+**承载子路由的位置一律用 `RouterViewKeepAlive`，不要写裸 `<router-view />`** ——
+后者渲染出的页面不受 `keep-alive` 管辖，多级菜单的缓存会失效。
+
+## 全局可用
+
+无需 import 即可使用：
+
+- 组件：`<BasicLayout>` `<AppPagination>` `<SvgIcon>` `<CodeEditor>`
+- 指令：`v-permisaction` `v-permission` `v-dialogDrag`
+- 方法：`this.$getDicts` `this.$parseTime` `this.$selectDictLabel`
+  `this.$msgSuccess` `this.$msgError`
+- Element Plus 图标已全局注册，模板中直接 `<el-icon><User /></el-icon>`
+
+## Vue 3 注意事项
+
+项目使用 Options API。以下 Vue 2 写法在当前版本**无效**，不要产出：
+
+| 失效写法 | 应改为 |
+|---|---|
+| `slot-scope="scope"` | `#default="scope"` |
+| `:visible.sync` `:page.sync` | `v-model:visible` `v-model:page` |
+| `@keyup.enter.native` | `@keyup.enter` |
+| `filters` 选项 | `$filters.xxx(val)` |
+| `this.$set` / `this.$delete` | 直接赋值 |
+| 指令 `bind` / `inserted` / `unbind` | `beforeMount` / `mounted` / `unmounted` |
+
+`el-tag` 的 `type` 只接受 `primary/success/info/warning/danger`，**空字符串是非法值**，
+会在每次渲染时触发 prop 校验告警。
+
+## 图标
+
+```vue
+<svg-icon icon-class="add-db" />   <!-- src/icons/svg/ 下的文件名 -->
+<i class="ri-home-line" />          <!-- Remix Icon 字体 -->
+```
+
+新增 SVG 后执行 `pnpm run svgo` 清理 `fill` 属性 —— 否则图标无法跟随主题色。
+
+## 提交规范
+
+格式 `type+emoji: 描述`：
+
+`feat✨` `fix🐛` `style💄` `docs📝` `perf👌` `test✅` `refactor🎨` `chore🔧`
+
+一个提交只做一件事。改动跨越多个语义时拆分提交，不要混在一起。
+
+## 红线
+
+- 不引入需要从外部 CDN 加载的资源 —— 内网与离线部署是常见场景
+- 不在业务代码里写死后端地址，一律通过 `VUE_APP_BASE_API`
+- 删除组件前先确认零引用（`grep` 文件路径、标签名、全局注册三处）
+- 提交前跑 `pnpm run lint` 与 `pnpm run test:unit`

--- a/src/api/demo/product.js
+++ b/src/api/demo/product.js
@@ -1,0 +1,43 @@
+import request from '@/utils/request'
+
+// 函数命名遵循 list / get / add / update / del 前缀约定，
+// 与后端 /api/v1/demo-product 的五个路由一一对应。
+
+export function listProduct(query) {
+  return request({
+    url: '/api/v1/demo-product',
+    method: 'get',
+    params: query
+  })
+}
+
+export function getProduct(id) {
+  return request({
+    url: '/api/v1/demo-product/' + id,
+    method: 'get'
+  })
+}
+
+export function addProduct(data) {
+  return request({
+    url: '/api/v1/demo-product',
+    method: 'post',
+    data
+  })
+}
+
+export function updateProduct(data) {
+  return request({
+    url: '/api/v1/demo-product/' + data.id,
+    method: 'put',
+    data
+  })
+}
+
+export function delProduct(data) {
+  return request({
+    url: '/api/v1/demo-product',
+    method: 'delete',
+    data
+  })
+}

--- a/src/mixins/crud.js
+++ b/src/mixins/crud.js
@@ -1,0 +1,162 @@
+/**
+ * 列表页通用逻辑。
+ *
+ * 各列表页的分页查询、搜索重置、多选、新增/修改弹窗、删除确认这几段代码此前
+ * 在每个页面各写一遍，实现完全相同，仅接口函数与主键字段名不同。此 mixin 将
+ * 其收敛，页面只需通过 crudOptions() 声明差异部分。
+ *
+ * 用法见 src/views/demo/product/index.vue。
+ *
+ * 页面需实现：
+ *   crudOptions() {
+ *     return {
+ *       api:  { list, get, add, update, del },  // 缺省的操作可不传
+ *       idKey: 'id',                            // 主键字段名，默认 'id'
+ *       defaultForm: () => ({ ... })            // 表单初始值
+ *     }
+ *   }
+ *
+ * mixin 提供的 data：list / total / loading / ids / single / multiple /
+ *   open / title / form / queryParams
+ *
+ * mixin 提供的方法：getList / handleQuery / resetQuery / handleSelectionChange /
+ *   handleAdd / handleUpdate / handleDelete / cancel / reset / submitForm
+ */
+export default {
+  data() {
+    return {
+      list: [],
+      total: 0,
+      loading: false,
+      // 选中项主键，供批量操作使用
+      ids: [],
+      // 是否恰好选中一项 / 是否未选中任何项，用于按钮禁用
+      single: true,
+      multiple: true,
+      open: false,
+      title: '',
+      form: {},
+      queryParams: {
+        pageIndex: 1,
+        pageSize: 10
+      }
+    }
+  },
+
+  computed: {
+    // 缓存 crudOptions() 的结果，避免每次访问都重新构造
+    crud() {
+      return {
+        idKey: 'id',
+        api: {},
+        defaultForm: () => ({}),
+        ...(typeof this.crudOptions === 'function' ? this.crudOptions() : {})
+      }
+    }
+  },
+
+  created() {
+    this.reset()
+  },
+
+  methods: {
+    getList() {
+      const { list } = this.crud.api
+      if (!list) return Promise.resolve()
+
+      this.loading = true
+      return list(this.queryParams)
+        .then(res => {
+          // 后端分页响应固定为 { data: { list, count } }
+          this.list = (res.data && res.data.list) || []
+          this.total = (res.data && res.data.count) || 0
+        })
+        .finally(() => {
+          this.loading = false
+        })
+    },
+
+    handleQuery() {
+      this.queryParams.pageIndex = 1
+      return this.getList()
+    },
+
+    resetQuery() {
+      this.resetForm('queryForm')
+      return this.handleQuery()
+    },
+
+    handleSelectionChange(selection) {
+      const key = this.crud.idKey
+      this.ids = selection.map(item => item[key])
+      this.single = selection.length !== 1
+      this.multiple = !selection.length
+    },
+
+    reset() {
+      this.form = this.crud.defaultForm()
+      this.resetForm('form')
+    },
+
+    cancel() {
+      this.open = false
+      this.reset()
+    },
+
+    handleAdd() {
+      this.reset()
+      this.open = true
+      this.title = '新增'
+    },
+
+    handleUpdate(row) {
+      this.reset()
+      const { get } = this.crud.api
+      const id = (row && row[this.crud.idKey]) || this.ids[0]
+      if (!get) return
+
+      return get(id).then(res => {
+        this.form = res.data
+        this.open = true
+        this.title = '修改'
+      })
+    },
+
+    submitForm() {
+      return this.$refs.form.validate(valid => {
+        if (!valid) return
+        const { add, update } = this.crud.api
+        const id = this.form[this.crud.idKey]
+        const action = id ? update : add
+        if (!action) return
+
+        return action(this.form).then(res => {
+          if (res.code !== 200) return this.msgError(res.msg)
+          this.msgSuccess(id ? '修改成功' : '新增成功')
+          this.open = false
+          this.getList()
+        })
+      })
+    },
+
+    handleDelete(row) {
+      const { del } = this.crud.api
+      if (!del) return
+
+      // 有 row 时删单条，否则删当前选中项
+      const ids = row ? [row[this.crud.idKey]] : this.ids
+      return this.$confirm(`确认删除选中的 ${ids.length} 条数据？`, '警告', {
+        confirmButtonText: '确定',
+        cancelButtonText: '取消',
+        type: 'warning'
+      })
+        .then(() => del({ ids }))
+        .then(res => {
+          if (res.code !== 200) return this.msgError(res.msg)
+          this.msgSuccess('删除成功')
+          this.getList()
+        })
+        .catch(() => {})
+    }
+  }
+}

--- a/src/views/demo/product/index.vue
+++ b/src/views/demo/product/index.vue
@@ -1,0 +1,165 @@
+<template>
+  <BasicLayout>
+    <template #wrapper>
+      <el-card class="box-card">
+        <!-- 搜索表单：prop 需与 queryParams 字段同名，resetQuery 依赖它重置 -->
+        <el-form ref="queryForm" :model="queryParams" :inline="true">
+          <el-form-item label="名称" prop="name">
+            <el-input
+              v-model="queryParams.name"
+              placeholder="请输入名称"
+              clearable
+              @keyup.enter="handleQuery"
+            />
+          </el-form-item>
+          <el-form-item label="状态" prop="status">
+            <el-select v-model="queryParams.status" placeholder="请选择状态" clearable>
+              <el-option label="正常" value="1" />
+              <el-option label="停用" value="2" />
+            </el-select>
+          </el-form-item>
+          <el-form-item>
+            <el-button type="primary" @click="handleQuery">搜索</el-button>
+            <el-button @click="resetQuery">重置</el-button>
+          </el-form-item>
+        </el-form>
+
+        <!-- 操作按钮：权限标识格式为 模块:资源:操作，需与后端菜单配置一致 -->
+        <el-row :gutter="10" class="mb8">
+          <el-col :span="1.5">
+            <el-button v-permisaction="['demo:product:add']" type="primary" @click="handleAdd">
+              新增
+            </el-button>
+          </el-col>
+          <el-col :span="1.5">
+            <el-button
+              v-permisaction="['demo:product:delete']"
+              type="danger"
+              :disabled="multiple"
+              @click="handleDelete()"
+            >
+              删除
+            </el-button>
+          </el-col>
+        </el-row>
+
+        <el-table v-loading="loading" :data="list" @selection-change="handleSelectionChange">
+          <el-table-column type="selection" width="55" align="center" />
+          <el-table-column label="名称" align="center" prop="name" :show-overflow-tooltip="true" />
+          <el-table-column label="编码" align="center" prop="code" />
+          <el-table-column label="单价" align="center" prop="price" />
+          <el-table-column label="状态" align="center">
+            <template #default="{ row }">
+              <el-tag :type="row.status === '1' ? 'success' : 'info'">
+                {{ row.status === '1' ? '正常' : '停用' }}
+              </el-tag>
+            </template>
+          </el-table-column>
+          <el-table-column label="创建时间" align="center" width="180">
+            <template #default="{ row }">
+              {{ $parseTime(row.createdAt) }}
+            </template>
+          </el-table-column>
+          <el-table-column label="操作" align="center" width="160">
+            <template #default="{ row }">
+              <el-button v-permisaction="['demo:product:edit']" link type="primary" @click="handleUpdate(row)">
+                修改
+              </el-button>
+              <el-button v-permisaction="['demo:product:delete']" link type="danger" @click="handleDelete(row)">
+                删除
+              </el-button>
+            </template>
+          </el-table-column>
+        </el-table>
+
+        <AppPagination
+          v-show="total > 0"
+          :total="total"
+          :page="queryParams.pageIndex"
+          :limit="queryParams.pageSize"
+          @update:page="val => (queryParams.pageIndex = val)"
+          @update:limit="val => (queryParams.pageSize = val)"
+          @pagination="getList"
+        />
+
+        <!-- 新增与修改共用同一个弹窗，由 form 中是否带主键区分 -->
+        <el-dialog v-model="open" :title="title" width="500px" :close-on-click-modal="false">
+          <el-form ref="form" :model="form" :rules="rules" label-width="80px">
+            <el-form-item label="名称" prop="name">
+              <el-input v-model="form.name" placeholder="请输入名称" />
+            </el-form-item>
+            <el-form-item label="编码" prop="code">
+              <el-input v-model="form.code" placeholder="请输入编码" />
+            </el-form-item>
+            <el-form-item label="单价" prop="price">
+              <el-input-number v-model="form.price" :min="0" :precision="2" />
+            </el-form-item>
+            <el-form-item label="状态" prop="status">
+              <el-radio-group v-model="form.status">
+                <el-radio value="1">正常</el-radio>
+                <el-radio value="2">停用</el-radio>
+              </el-radio-group>
+            </el-form-item>
+            <el-form-item label="备注" prop="remark">
+              <el-input v-model="form.remark" type="textarea" placeholder="请输入内容" />
+            </el-form-item>
+          </el-form>
+          <template #footer>
+            <el-button type="primary" @click="submitForm">确 定</el-button>
+            <el-button @click="cancel">取 消</el-button>
+          </template>
+        </el-dialog>
+      </el-card>
+    </template>
+  </BasicLayout>
+</template>
+
+<script>
+import crud from '@/mixins/crud'
+import { listProduct, getProduct, addProduct, updateProduct, delProduct } from '@/api/demo/product'
+
+export default {
+  // name 必须与后端菜单配置的 menu_name 一致，否则 keep-alive 缓存无法命中
+  name: 'DemoProduct',
+
+  mixins: [crud],
+
+  data() {
+    return {
+      // 仅声明本页特有的内容；list/total/loading/open/form 等由 crud mixin 提供
+      rules: {
+        name: [{ required: true, message: '名称不能为空', trigger: 'blur' }],
+        code: [{ required: true, message: '编码不能为空', trigger: 'blur' }]
+      }
+    }
+  },
+
+  created() {
+    this.getList()
+  },
+
+  methods: {
+    // 向 crud mixin 声明差异部分：接口、主键字段、表单初始值
+    crudOptions() {
+      return {
+        idKey: 'id',
+        api: {
+          list: listProduct,
+          get: getProduct,
+          add: addProduct,
+          update: updateProduct,
+          del: delProduct
+        },
+        defaultForm: () => ({
+          id: undefined,
+          name: undefined,
+          code: undefined,
+          price: 0,
+          status: '1',
+          remark: undefined
+        })
+      }
+    }
+  }
+}
+</script>

--- a/tests/unit/mixins/crud.spec.js
+++ b/tests/unit/mixins/crud.spec.js
@@ -1,0 +1,147 @@
+import crud from '@/mixins/crud'
+
+// crud mixin 是所有列表页的公共基础，行为变化会同时影响多个页面，
+// 因此对其关键约定加测试锁定。
+
+// 构造一个最小宿主，模拟 Vue 组件实例上 mixin 依赖的外部能力
+function makeVm(options = {}, overrides = {}) {
+  const vm = {
+    ...crud.data(),
+    crudOptions: () => options,
+    // 全局方法（由 main.js 注入）
+    resetForm: jest.fn(),
+    msgSuccess: jest.fn(),
+    msgError: jest.fn(),
+    $confirm: jest.fn(() => Promise.resolve()),
+    $refs: { form: { validate: cb => cb(true) } },
+    ...overrides
+  }
+  Object.defineProperty(vm, 'crud', {
+    get: () => crud.computed.crud.call(vm)
+  })
+  Object.entries(crud.methods).forEach(([k, fn]) => {
+    vm[k] = fn.bind(vm)
+  })
+  return vm
+}
+
+describe('Mixins:crud', () => {
+  it('未声明 crudOptions 时提供安全默认值', () => {
+    const vm = makeVm()
+    expect(vm.crud.idKey).toBe('id')
+    expect(vm.crud.api).toEqual({})
+    expect(vm.crud.defaultForm()).toEqual({})
+  })
+
+  it('getList 按 { data: { list, count } } 结构解析响应', async () => {
+    const list = jest.fn(() => Promise.resolve({ data: { list: [{ id: 1 }], count: 7 } }))
+    const vm = makeVm({ api: { list } })
+
+    await vm.getList()
+
+    expect(vm.list).toEqual([{ id: 1 }])
+    expect(vm.total).toBe(7)
+    expect(vm.loading).toBe(false)
+  })
+
+  it('getList 出错后 loading 必须归位', async () => {
+    const list = jest.fn(() => Promise.reject(new Error('boom')))
+    const vm = makeVm({ api: { list } })
+
+    await vm.getList().catch(() => {})
+
+    expect(vm.loading).toBe(false)
+  })
+
+  it('未提供 list 接口时不抛异常', async () => {
+    const vm = makeVm()
+    await expect(vm.getList()).resolves.toBeUndefined()
+  })
+
+  it('handleQuery 重置到第一页', async () => {
+    const list = jest.fn(() => Promise.resolve({ data: { list: [], count: 0 } }))
+    const vm = makeVm({ api: { list } })
+    vm.queryParams.pageIndex = 5
+
+    await vm.handleQuery()
+
+    expect(vm.queryParams.pageIndex).toBe(1)
+  })
+
+  it('handleSelectionChange 按 idKey 取主键并维护禁用状态', () => {
+    const vm = makeVm({ idKey: 'postId' })
+
+    vm.handleSelectionChange([{ postId: 3 }, { postId: 8 }])
+    expect(vm.ids).toEqual([3, 8])
+    expect(vm.single).toBe(true) // 非恰好一项
+    expect(vm.multiple).toBe(false)
+
+    vm.handleSelectionChange([{ postId: 3 }])
+    expect(vm.single).toBe(false) // 恰好一项
+    expect(vm.multiple).toBe(false)
+
+    vm.handleSelectionChange([])
+    expect(vm.ids).toEqual([])
+    expect(vm.multiple).toBe(true)
+  })
+
+  it('handleAdd 重置表单并打开弹窗', () => {
+    const vm = makeVm({ defaultForm: () => ({ name: '默认' }) })
+    vm.form = { name: '脏数据' }
+
+    vm.handleAdd()
+
+    expect(vm.form).toEqual({ name: '默认' })
+    expect(vm.open).toBe(true)
+  })
+
+  it('submitForm 按主键有无选择新增或修改', async () => {
+    const add = jest.fn(() => Promise.resolve({ code: 200 }))
+    const update = jest.fn(() => Promise.resolve({ code: 200 }))
+    const list = jest.fn(() => Promise.resolve({ data: { list: [], count: 0 } }))
+
+    const vmAdd = makeVm({ api: { add, update, list } })
+    vmAdd.form = { id: undefined, name: '新' }
+    await vmAdd.submitForm()
+    expect(add).toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+
+    const vmUpd = makeVm({ api: { add, update, list } })
+    vmUpd.form = { id: 9, name: '改' }
+    await vmUpd.submitForm()
+    expect(update).toHaveBeenCalled()
+  })
+
+  it('校验未通过时不提交', async () => {
+    const add = jest.fn()
+    const vm = makeVm({ api: { add } }, { $refs: { form: { validate: cb => cb(false) } } })
+    vm.form = { name: '' }
+
+    await vm.submitForm()
+
+    expect(add).not.toHaveBeenCalled()
+  })
+
+  it('handleDelete 传 row 时删单条，不传时删选中项', async () => {
+    const del = jest.fn(() => Promise.resolve({ code: 200 }))
+    const list = jest.fn(() => Promise.resolve({ data: { list: [], count: 0 } }))
+
+    const vm = makeVm({ api: { del, list } })
+    vm.ids = [1, 2, 3]
+
+    await vm.handleDelete({ id: 42 })
+    expect(del).toHaveBeenLastCalledWith({ ids: [42] })
+
+    await vm.handleDelete()
+    expect(del).toHaveBeenLastCalledWith({ ids: [1, 2, 3] })
+  })
+
+  it('取消删除确认时不调用接口', async () => {
+    const del = jest.fn()
+    const vm = makeVm({ api: { del } }, { $confirm: () => Promise.reject(new Error('cancel')) })
+
+    await vm.handleDelete({ id: 1 })
+
+    expect(del).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## 背景

配合 go-admin Discussion #851 —— 移除代码生成器，改由**代码规范 + 参照页面**
承担同样的职责。本 PR 是前端部分。

## 改动

### `src/mixins/crud.js` —— 列表页公共逻辑

分页查询、搜索重置、多选、新增/修改弹窗、删除确认这几段代码，此前在每个列表页
各写一遍，实现完全相同，仅接口函数与主键字段名不同。以 sys-post 为例，319 行中
约 8 个方法属于这类样板。

收敛后页面只声明差异部分：

```js
crudOptions() {
  return {
    idKey: 'id',
    api: { list, get, add, update, del },
    defaultForm: () => ({ id: undefined, name: undefined })
  }
}
```

mixin 提供 `list` `total` `loading` `ids` `single` `multiple` `open` `title`
`form` `queryParams`，以及 `getList` `handleQuery` `resetQuery`
`handleSelectionChange` `handleAdd` `handleUpdate` `handleDelete` `cancel`
`submitForm`。

11 项测试锁定关键约定：`{ data: { list, count } }` 响应结构解析、出错后 `loading`
必须归位、按 `idKey` 取主键、按主键有无选择新增或修改、校验未通过不提交、删除
确认取消后不调接口。

**本 PR 不改动任何现有页面**，仅提供基础设施与参照。存量页面可按需逐个迁移。

### `src/views/demo/product/` —— 参照页面

与后端 `app/demo` 一一对应。展示标准列表页的完整结构：`BasicLayout` + `#wrapper`
插槽、搜索表单、`v-permisaction` 按钮级权限、`el-table`、`AppPagination`、新增与
修改共用弹窗。

业务代码只剩模板、校验规则与 `crudOptions()`。

组件 `name` 取 `DemoProduct`，与后端菜单 `menu_name` 一致 —— 两者不一致时
`keep-alive` 会静默失效。

### `AGENTS.md`

给 AI 编码工具与新贡献者的约定，只写"不遵守就会出错"的规则：

- 组件 `name` 与后端 `menu_name` 的一致性要求
- 上传文件必须传 `FormData`（否则被拦截器序列化成 JSON）
- 承载子路由一律用 `RouterViewKeepAlive`，裸 `<router-view />` 会让多级菜单缓存失效
- Vue 2 失效写法对照表（`slot-scope` / `:visible.sync` / `filters` / `this.$set` 等）
- `el-tag` 的 `type` 不接受空字符串

依赖版本与命令不复述，以 `package.json` 为准。

## 验证

- `eslint src --ext .js,.vue` —— 0 error
- `jest` —— 11 个测试文件、60 项测试全部通过
- 生产构建通过，demo 页面正确分片为 `dist/js/product.*.js`
- 确认 `loadView('/demo/product/index')` 能命中 `import.meta.glob` 索引

## 配套

后端参照模块见 go-admin-team/go-admin#854，两个 PR 需一并合并 ——
本页面的接口与菜单入口由后端 PR 提供。
