### PR TITLE
fix🐛: 移除刷新 token 的客户端死代码

### DIFF
--- a/src/api/user.js
+++ b/src/api/user.js
@@ -17,16 +17,6 @@ export function logout() {
   })
 }
 
-// refreshtoken 刷新token
-// 后端路由为 GET /api/v1/refresh_token（app/admin/router/sys_router.go），
-// 此处此前写的是 POST /refreshtoken，路径与方法均不匹配，调用必然 404
-export function refreshtoken() {
-  return request({
-    url: '/api/v1/refresh_token',
-    method: 'get'
-  })
-}
-
 // getInfo 获取用户基本信息
 export function getInfo() {
   return request({

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -1,4 +1,4 @@
-import { login, logout, getInfo, refreshtoken } from '@/api/user'
+import { login, logout, getInfo } from '@/api/user'
 import { getToken, setToken, removeToken } from '@/utils/auth'
 import router, { resetRouter } from '@/router'
 import storage from '@/utils/storage'
@@ -95,20 +95,6 @@ const actions = {
       })
     })
   },
-  // 刷新token
-  refreshToken({ commit, state }) {
-    return new Promise((resolve, reject) => {
-      refreshtoken({ token: state.token }).then(response => {
-        const { token } = response
-        commit('SET_TOKEN', token)
-        setToken(token)
-        resolve()
-      }).catch(error => {
-        reject(error)
-      })
-    })
-  },
-
   // remove token
   resetToken({ commit }) {
     return new Promise(resolve => {


### PR DESCRIPTION
配合 go-admin-team/go-admin#855 移除 `GET /api/v1/refresh_token`。

## 背景

该接口用业务 token 即可换取新 token，而续期上限 `MaxRefresh` 依据的
`orig_iat` 每次续期都被重置 —— token 一旦泄露即等同于永久访问权。
详见 go-admin-team/go-admin#820。

## 改动

删除两处从未被调用的代码：

| 位置 | 内容 |
|---|---|
| `src/store/modules/user.js` | `refreshToken` action |
| `src/api/user.js` | `refreshtoken()` |

全仓库无一处 `dispatch('user/refreshToken')`，本身就是死代码；后端接口下线后
更无保留意义。

## 验证

- `grep -rni "refreshtoken\|refresh_token" src/` 无结果
- ESLint 0 error
- 60 项单元测试全部通过
