### PR TITLE
chore🔧: 版本号升至 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-admin",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A magical vue admin. An out-of-box UI solution for enterprise applications. Newest development stack of vue. Lots of awesome features",
   "author": "https://github.com/wenjianzhang",
   "license": "MIT",


### PR DESCRIPTION
配合 go-admin v2.4.0 发布 go-admin-ui v3.1.0。

本次含新功能（crud mixin、demo 参照页面），按 minor 递增。