### PR TITLE
ci: retry a failed e2e test in CI, and report the rate

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,33 @@ process.env.no_proxy = process.env.NO_PROXY;
 export default defineConfig({
   testDir: './tests/e2e',
   timeout: 30_000,
-  retries: 0,
+
+  /**
+   * Retries in CI, none locally.
+   *
+   * The suite fails in one shape that has nothing to do with the code under
+   * test: a single `page.goto` stalls until it eats the whole 30s test timeout,
+   * on a different test each time, only on the runner. Everything before and
+   * after it finishes in three or four seconds. Observed twice in three runs,
+   * once in app-shell and once in sys-user; the same commits pass locally and
+   * pass on a rerun.
+   *
+   * It was not diagnosed. What was ruled out: the dev server logs no
+   * re-optimisation, no reload and no transform error across a full local run;
+   * the suite takes 8-9 minutes whether it goes red or green, so it is not
+   * running out of some overall budget.
+   *
+   * With `retries: 0` one such stall turns the whole gate red, and a gate that
+   * goes red for reasons nobody can explain is one people learn to re-run
+   * without reading. Retrying does not hide it: Playwright reports a test that
+   * needed a retry as `flaky`, so the rate stays visible in the run output. If
+   * that rate climbs, something real is behind it and this comment is the
+   * starting point.
+   *
+   * Locally the number stays 0, so a test that fails on a developer's machine
+   * fails immediately rather than after three tries.
+   */
+  retries: process.env.CI ? 2 : 0,
 
   /**
    * One worker. Every spec drives the same Vite dev server, so the runs compete


### PR DESCRIPTION
The e2e gate has started going red for a reason that is not in the code under test. This changes what one such failure costs, without hiding it.

## The failure

A single `page.goto` stalls until it eats the whole 30s test timeout. A different test each time, only on the runner:

| run | test that failed | how long |
|---|---|---|
| 1 | `app-shell.spec.ts:31` — the svg sprite is injected | 31.4s |
| 2 | `sys-user.spec.ts:126` — a double-clicked confirm button | 31.4s |
| 3 | — | 132 passed |

Everything before and after the failing test finishes in three or four seconds. The same commits pass locally three times out of three, and the branch passed on its third CI run.

## What was ruled out

- **Not the sprite test, or any one test.** Two runs, two different tests, same shape.
- **Not Vite re-optimising mid-run.** `write-excel-file` is pre-bundled at server start, and a full local run logs no re-optimisation, no reload, no transform error — zero Vite events.
- **Not an overall budget.** The suite takes 8–9 minutes whether it ends red or green, across twelve runs on `master` and three on the branch.

It is **not diagnosed**. This PR does not claim to fix it.

## What this changes

`retries: process.env.CI ? 2 : 0`.

At `retries: 0`, one stall turns the whole gate red. A gate that goes red for reasons nobody can explain is one people learn to re-run without reading — and that is how a real failure gets waved through six weeks from now.

Retrying does not bury it. Playwright reports a test that needed a retry as **`flaky`**, not as passed, so the rate stays in the run output. If it climbs, something real is behind it, and the comment in the config is the starting point for whoever picks it up.

Locally the count stays `0`, so a test that fails on a developer's machine fails on the first attempt rather than after three.

## Verification

A test that always fails, run both ways:

```
CI unset   ✘ probe: always fails (4ms)                      -> 1 attempt
CI=true    ✘ probe: always fails (4ms)
           ✘ probe: always fails (retry #1) (4ms)
           ✘ probe: always fails (retry #2) (4ms)           -> 3 attempts
```

A genuinely broken test still fails the run in both cases. Only a test that passes on a later attempt is marked flaky.

lint 0 errors (29 pre-existing warnings) · type-check clean.
