### PR TITLE
fix: repair the sidebar logo and the light rail, and take the palette from Ant Design

### DIFF
--- a/src/layout/components/Sidebar/Logo.vue
+++ b/src/layout/components/Sidebar/Logo.vue
@@ -70,8 +70,8 @@ export default {
   // gradient, which put the most saturated block in the interface against the
   // darkest one and read as a patch rather than a header -- and on a light rail
   // it would have been the only saturated thing on screen.
-  background: var(--ga-sidebar-bg);
-  border-bottom: 1px solid transparent;
+  background: var(--rail-bg);
+  border-bottom: 1px solid var(--rail-border);
   text-align: center;
   overflow: hidden;
 
@@ -96,14 +96,14 @@ export default {
       vertical-align: middle;
       margin-right: 10px;
       border-radius: 6px;
-      border: 1px solid rgba(255, 255, 255, 0.25);
+      border: 1px solid var(--rail-border);
       flex-shrink: 0;
     }
 
     & .sidebar-title {
       display: inline-block;
       margin: 0;
-      color: var(--ga-sidebar-title);
+      color: var(--rail-title);
       font-weight: 600;
       font-size: 15px;
       font-family: Avenir, Helvetica Neue, Arial, Helvetica, sans-serif;

--- a/src/layout/components/Sidebar/Logo.vue
+++ b/src/layout/components/Sidebar/Logo.vue
@@ -1,14 +1,14 @@
 <template>
-  <div class="sidebar-logo-container" :class="{'collapse':collapse}" :style="{ backgroundColor: themeStyle === 'dark' ? variables.menuBg : variables.menuLightBg }">
+  <div class="sidebar-logo-container" :class="{'collapse':collapse}">
     <transition name="sidebarLogoFade">
       <router-link v-if="collapse" key="collapse" class="sidebar-logo-link" to="/">
         <img v-if="showLogo" :src="appInfo.sys_app_logo" class="sidebar-logo" @error="showLogo = false">
         <!-- 折叠后仅 54px，完整应用名会被裁成半截文字，改用首字母作标记 -->
-        <h1 v-else class="sidebar-title sidebar-title--mark" :title="appName" :style="{ color: titleColor }">{{ monogram }}</h1>
+        <h1 v-else class="sidebar-title sidebar-title--mark" :title="appName">{{ monogram }}</h1>
       </router-link>
       <router-link v-else key="expand" class="sidebar-logo-link" to="/">
         <img v-if="showLogo" :src="appInfo.sys_app_logo" class="sidebar-logo" @error="showLogo = false">
-        <h1 class="sidebar-title" :style="{ color: titleColor }">{{ appName }}</h1>
+        <h1 class="sidebar-title">{{ appName }}</h1>
       </router-link>
     </transition>
   </div>
@@ -16,10 +16,8 @@
 
 <script>
 
-import variables from '@/styles/variables.module.scss'
 import { mapState } from 'pinia'
 import { useSystemStore } from '@/stores/system'
-import { useSettingsStore } from '@/stores/settings'
 
 export default {
   name: 'SidebarLogo',
@@ -34,17 +32,8 @@ export default {
   },
   computed: {
     ...mapState(useSystemStore, { appInfo: 'info' }),
-    ...mapState(useSettingsStore, ['themeStyle']),
-    variables() {
-      return variables
-    },
     appName() {
       return (this.appInfo && this.appInfo.sys_app_name) || 'Go Admin'
-    },
-    titleColor() {
-      return this.themeStyle === 'dark'
-        ? variables.sidebarTitle
-        : variables.sidebarLightTitle
     },
     monogram() {
       return this.appName.trim().charAt(0).toUpperCase()
@@ -77,13 +66,14 @@ export default {
   width: 100%;
   height: 64px;
   line-height: 64px;
-  background: linear-gradient(135deg,
-    color-mix(in oklab, var(--ga-brand), #000 45%) 0%,
-    var(--ga-brand) 60%,
-    var(--el-color-primary-light-3) 100%);
+  // Part of the rail, not a plaque laid on top of it. This was a brand-colour
+  // gradient, which put the most saturated block in the interface against the
+  // darkest one and read as a patch rather than a header -- and on a light rail
+  // it would have been the only saturated thing on screen.
+  background: var(--ga-sidebar-bg);
+  border-bottom: 1px solid transparent;
   text-align: center;
   overflow: hidden;
-  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.08);
 
   & .sidebar-logo-link {
     // 绝对定位使折叠/展开两个链接在过渡期重叠而非互相挤压，
@@ -113,8 +103,8 @@ export default {
     & .sidebar-title {
       display: inline-block;
       margin: 0;
-      color: #fff;
-      font-weight: 700;
+      color: var(--ga-sidebar-title);
+      font-weight: 600;
       font-size: 15px;
       font-family: Avenir, Helvetica Neue, Arial, Helvetica, sans-serif;
       letter-spacing: 0.5px;

--- a/src/layout/components/Sidebar/SidebarItem.vue
+++ b/src/layout/components/Sidebar/SidebarItem.vue
@@ -24,7 +24,11 @@
       </el-menu-item>
     </template>
 
-    <el-sub-menu v-else ref="subMenu" :index="resolvePath(item.path)" :style="{ backgroundColor: '#000c17' }">
+    <!-- No inline background here. It used to carry a hard-coded #000c17, which
+         no setting could reach: the light rail turned everything around it white
+         and left this wrapper dark. The rail's own surface shows through, and
+         the rows on it are coloured in styles/sidebar.scss. -->
+    <el-sub-menu v-else ref="subMenu" :index="resolvePath(item.path)">
       <template #title>
         <!-- 官方折叠样式选择器为 .el-menu--collapse > .el-sub-menu > .el-sub-menu__title > span，
              span 必须是直接子元素，中间不能再包一层容器 -->

--- a/src/layout/components/Sidebar/index.vue
+++ b/src/layout/components/Sidebar/index.vue
@@ -2,11 +2,14 @@
   <div :class="{'has-logo':showLogo}">
     <logo v-if="showLogo" :collapse="isCollapse" />
     <el-scrollbar wrap-class="scrollbar-wrapper">
+      <!-- No background-color or text-color props: Element Plus turns those
+           into inline styles that the stylesheet then has to out-!important,
+           which is how the light rail came to render white text on white.
+           Colours come from the --rail-* variables instead, resolved by the
+           rail class the layout puts on the container. -->
       <el-menu
         :default-active="activeMenu"
         :collapse="isCollapse"
-        :background-color="themeStyle === 'light' ? variables.menuLightBg : variables.menuBg"
-        :text-color="themeStyle === 'light' ? 'rgba(0,0,0,.65)' : '#fff'"
         :active-text-color="theme"
         :unique-opened="true"
         :collapse-transition="true"

--- a/src/layout/index.vue
+++ b/src/layout/index.vue
@@ -1,7 +1,9 @@
 <template>
   <div :class="classObj" class="app-wrapper" :style="{'--current-color': theme}">
     <div v-if="device==='mobile'&&sidebar.opened" class="drawer-bg" @click="handleClickOutside" />
-    <sidebar class="sidebar-container" :style="{ backgroundColor: themeStyle === 'dark' ? variables.menuBg : variables.menuLightBg }" />
+    <!-- The rail class resolves one set of --rail-* variables for everything
+         inside it; see the sidebar rail block in styles/tokens.css. -->
+    <sidebar class="sidebar-container" :class="`rail-${themeStyle}`" />
     <div :class="{hasTagsView:needTagsView}" class="main-container">
       <div :class="{'fixed-header':fixedHeader}">
         <navbar @open-settings="settingsOpen = true" />

--- a/src/settings.js
+++ b/src/settings.js
@@ -39,5 +39,15 @@ export default {
    */
   errorLog: 'production',
 
-  themeStyle: 'dark'
+  /**
+   * Sidebar surface: 'light' or 'dark', switched from the settings drawer.
+   *
+   * Light is the default because it is what the systems this gets compared
+   * against do, Ant Design Pro among them: navigation and content share one
+   * plane separated by a hairline, and the accent is spent on the few things
+   * that are actually interactive rather than on the largest block of screen
+   * nobody looks at. The dark rail is one switch away for deployments that
+   * prefer it, and both are covered by tests/e2e/mocked/sidebar-rail.spec.ts.
+   */
+  themeStyle: 'light'
 }

--- a/src/styles/sidebar.scss
+++ b/src/styles/sidebar.scss
@@ -13,7 +13,8 @@
     -webkit-transition: width .28s;
     transition: width 0.28s;
     width: $sideBarWidth !important;
-    background-color: $menuBg;
+    background-color: var(--rail-bg);
+    border-right: 1px solid var(--rail-border);
     height: 100%;
     position: fixed;
     font-size: 0px;
@@ -22,8 +23,7 @@
     left: 0;
     z-index: 1001;
     overflow: hidden;
-    -webkit-box-shadow: 2px 0 6px rgba(0, 21, 41, .35);
-    box-shadow: 2px 0 6px rgba(0, 21, 41, .35);
+    box-shadow: var(--rail-shadow);
 
     .horizontal-collapse-transition {
       transition: 0s width ease-in-out, 0s padding-left ease-in-out, 0s padding-right ease-in-out;
@@ -72,19 +72,21 @@
       border: none;
       height: 100%;
       width: 100% !important;
-      --el-menu-bg-color: #{$menuBg};
-      background-color: $menuBg !important;
+      --el-menu-bg-color: var(--rail-bg);
+      background-color: var(--rail-bg) !important;
       border-right: none !important;
     }
 
-    // 外链菜单项由 a 标签承载（不参与路由），该层不应影响菜单布局与配色
+    // External-link rows are carried by an <a> that takes no part in routing;
+    // this layer must not affect the menu's own layout or colour.
     .sidebar-external-link {
       display: block;
       text-decoration: none;
       color: inherit;
     }
 
-    // 统一菜单项高度（Element Plus 2.x 默认 56px 偏大，收紧至 50px）
+    // One row height throughout: Element Plus 2.x defaults to 56px, which is
+    // tall for a dense admin menu.
     .el-menu-item,
     .el-sub-menu__title,
     .el-submenu__title {
@@ -93,63 +95,65 @@
       overflow: hidden !important;
       text-overflow: ellipsis !important;
       white-space: nowrap !important;
-      color: #fff !important;
+      color: var(--rail-text) !important;
     }
 
-    // 顶级 el-menu-item（如"首页"）必须设置深色背景，否则白字不可见
+    // Top-level rows paint the rail behind themselves: Element Plus leaves
+    // them transparent, which shows the scrollbar track through.
     .el-menu-item {
-      background-color: $menuBg !important;
+      background-color: var(--rail-bg) !important;
 
       &:hover {
-        background-color: $menuHover !important;
+        background-color: var(--rail-hover) !important;
       }
 
       &.is-active {
-        background-color: $subMenuBg !important;
-        color: $menuActiveText !important;
+        background-color: var(--rail-active-bg) !important;
+        color: var(--rail-active-text) !important;
       }
     }
 
-    // 展开的子菜单 el-menu-item 强制暗色背景 + 白色文字
+    // Rows inside an expanded submenu sit on the recessed surface.
     .el-sub-menu .el-menu-item,
     .el-submenu .el-menu-item {
-      background-color: $subMenuBg !important;
-      color: #fff !important;
+      background-color: var(--rail-bg-sub) !important;
+      color: var(--rail-text) !important;
       min-width: $sideBarWidth !important;
 
       &:hover {
-        background-color: $subMenuHover !important;
+        background-color: var(--rail-hover) !important;
       }
 
       &.is-active {
-        color: $menuActiveText !important;
+        background-color: var(--rail-active-bg) !important;
+        color: var(--rail-active-text) !important;
       }
     }
 
-    // 嵌套子菜单标题
+    // Nested submenu titles.
     .nest-menu .el-sub-menu > .el-sub-menu__title,
     .nest-menu .el-submenu > .el-submenu__title {
-      background-color: $subMenuBg !important;
-      color: #fff !important;
+      background-color: var(--rail-bg-sub) !important;
+      color: var(--rail-text) !important;
       min-width: $sideBarWidth !important;
 
       &:hover {
-        background-color: $subMenuHover !important;
+        background-color: var(--rail-hover) !important;
       }
     }
 
-    // 父级菜单标题 hover 效果
+    // Hover on a row that opens a submenu.
     .submenu-title-noDropdown,
     .el-sub-menu__title,
     .el-submenu__title {
       &:hover {
-        background-color: $menuHover !important;
+        background-color: var(--rail-hover) !important;
       }
     }
 
     .is-active > .el-sub-menu__title,
     .is-active > .el-submenu__title {
-      color: $subMenuActiveText !important;
+      color: var(--rail-active-text) !important;
     }
   }
 

--- a/src/styles/sidebar.scss
+++ b/src/styles/sidebar.scss
@@ -51,11 +51,18 @@
       display: none;
     }
 
-    a {
-      display: inline-block;
-      width: 100%;
-      overflow: hidden;
-    }
+    // A bare `a` rule used to sit here, from the template this sidebar started
+    // as, where every menu row was wrapped in a link. Element Plus renders rows
+    // as <li>, so the only anchor left in the sidebar is the logo link -- and
+    // because this whole file is nested under #app, `display: inline-block` beat
+    // the scoped `display: flex` the logo is laid out with (an id outranks any
+    // number of classes). The logo link is absolutely positioned, which
+    // blockifies inline-block, so it computed to `block`, `align-items` and
+    // `justify-content` went inert, and the 28px image was dropped onto the
+    // baseline of a 64px line box and clipped in half by the header's
+    // overflow: hidden. What the rule was there for is covered elsewhere:
+    // external links carry .sidebar-external-link with its own display: block,
+    // and .el-menu-item sets overflow: hidden !important below.
 
     .svg-icon {
       margin-right: 16px;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -22,57 +22,68 @@
 :root {
   /* ── Brand ────────────────────────────────────────────────────────
    * Change this one value to retheme the application.
-   * A cyan-leaning blue: distinct from the Ant Design blue that most admin
-   * templates ship with, and a nod to Go's own palette, while staying calm
-   * enough for large surfaces.
+   *
+   * Ant Design 5's colorPrimary. The palette below follows the rest of that
+   * system too, because this is a framework other people build admin panels on
+   * and the least surprising thing it can look like is the one every Chinese
+   * admin panel already looks like. It is also what index.html's first-paint
+   * loader has always used, so the two finally agree.
    */
-  --ga-brand: #0d7d9e;
+  --ga-brand: #1677ff;
 
   /* Direction tints are mixed toward. Flipped under .dark so the single set of
    * derivation rules below works for both themes. */
   --ga-mix-toward: #ffffff;
 
-  /* ── Semantic colours ─────────────────────────────────────────── */
-  --ga-success: #16a34a;
-  --ga-warning: #d97706;
-  --ga-danger:  #dc2626;
-  --ga-info:    #64748b;
+  /* ── Semantic colours ─────────────────────────────────────────
+   * Ant Design 5's success / warning / error. Brighter than the Tailwind ramp
+   * they replace, which is the point: a status column is read at a glance and
+   * these separate at small sizes. */
+  --ga-success: #52c41a;
+  --ga-warning: #faad14;
+  --ga-danger:  #ff4d4f;
+  --ga-info:    #8c8c8c;
 
   /* ── Neutrals ──────────────────────────────────────────────────
-   * Biased slightly toward the brand hue rather than pure grey, so surfaces
-   * read as chosen instead of defaulted.
+   * Ant Design 5's neutral ramp, which is achromatic: text is black at four
+   * opacities, surfaces are true greys. These used to carry a slight brand tint
+   * so they would "read as chosen"; next to a blue accent that tint is what
+   * made the greys look faintly green instead.
    */
-  --ga-bg-body:      #eef1f4;
-  --ga-bg-container: #ffffff;
-  --ga-bg-elevated:  #ffffff;
-  --ga-bg-subtle:    #f5f7f9;
-  --ga-bg-hover:     rgba(13, 125, 158, 0.06);
+  --ga-bg-body:      #f5f5f5;  /* colorBgLayout */
+  --ga-bg-container: #ffffff;  /* colorBgContainer */
+  --ga-bg-elevated:  #ffffff;  /* colorBgElevated */
+  --ga-bg-subtle:    #fafafa;  /* table headers, striped rows */
+  --ga-bg-hover:     rgba(0, 0, 0, 0.04);  /* colorFillTertiary */
 
-  --ga-text-1:        rgba(15, 27, 33, 0.88);
-  --ga-text-2:        rgba(15, 27, 33, 0.65);
-  --ga-text-3:        rgba(15, 27, 33, 0.45);
-  --ga-text-disabled: rgba(15, 27, 33, 0.28);
+  --ga-text-1:        rgba(0, 0, 0, 0.88);
+  --ga-text-2:        rgba(0, 0, 0, 0.65);
+  --ga-text-3:        rgba(0, 0, 0, 0.45);
+  --ga-text-disabled: rgba(0, 0, 0, 0.25);
   --ga-text-inverse:  #ffffff;
 
-  --ga-border:       #d6dee2;
-  --ga-border-light: #e8edf0;
+  --ga-border:       #d9d9d9;  /* colorBorder */
+  --ga-border-light: #f0f0f0;  /* colorBorderSecondary */
 
   /* ── Sidebar ───────────────────────────────────────────────────
-   * Its own scale: in light mode this is a dark surface, so it cannot inherit
-   * the neutral ramp above. Tinted with the brand hue instead of the flat navy
-   * the template shipped with.
+   * Two sets, chosen by the themeStyle setting. The light one is the default
+   * (src/settings.js) and is what Ant Design Pro does: the navigation is a
+   * white plane like the content, separated by a hairline rather than by
+   * inversion, so the page reads as one surface instead of two.
+   *
+   * The dark set stays for deployments that prefer it, and is now navy rather
+   * than the teal it was -- it has to sit under the same blue accent.
    */
-  --ga-sidebar-bg:        #0f2b35;
-  --ga-sidebar-bg-sub:    #0b222a;
-  --ga-sidebar-hover:     #143b48;
-  --ga-sidebar-text:      rgba(255, 255, 255, 0.72);
+  --ga-sidebar-bg:        #001529;
+  --ga-sidebar-bg-sub:    #000c17;
+  --ga-sidebar-hover:     #0a2540;
+  --ga-sidebar-text:      rgba(255, 255, 255, 0.65);
   --ga-sidebar-text-active: #ffffff;
   --ga-sidebar-title:     #ffffff;
 
-  /* Light-themed sidebar, selected via the themeStyle setting */
   --ga-sidebar-light-bg:    #ffffff;
-  --ga-sidebar-light-hover: #eef5f8;
-  --ga-sidebar-light-title: #0f2b35;
+  --ga-sidebar-light-hover: rgba(0, 0, 0, 0.04);
+  --ga-sidebar-light-title: rgba(0, 0, 0, 0.88);
 
   /* ── Shape ─────────────────────────────────────────────────────── */
   --ga-radius-sm: 4px;
@@ -83,53 +94,55 @@
    * Deliberately shallow. Admin surfaces are dense; heavy shadows on every
    * card turn a table page into a relief map.
    */
-  --ga-shadow-sm: 0 1px 2px rgba(15, 27, 33, 0.04);
-  --ga-shadow:    0 1px 2px rgba(15, 27, 33, 0.04), 0 2px 8px rgba(15, 27, 33, 0.04);
-  --ga-shadow-lg: 0 4px 16px rgba(15, 27, 33, 0.10);
+  --ga-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.03);
+  --ga-shadow:    0 1px 2px rgba(0, 0, 0, 0.03), 0 2px 8px rgba(0, 0, 0, 0.04);
+  --ga-shadow-lg: 0 4px 16px rgba(0, 0, 0, 0.08);
 }
 
 .dark {
-  --ga-brand: #3aa5c7;
+  /* Ant Design 5's dark algorithm: the same hues, pulled down so they do not
+   * glare on a black ground. */
+  --ga-brand: #1668dc;
   --ga-mix-toward: #000000;
 
-  --ga-success: #22c55e;
-  --ga-warning: #f59e0b;
-  --ga-danger:  #ef4444;
-  --ga-info:    #94a3b8;
+  --ga-success: #49aa19;
+  --ga-warning: #d89614;
+  --ga-danger:  #dc4446;
+  --ga-info:    #8c8c8c;
 
   /* Light mode separates the sidebar by inverting it; dark mode cannot, so the
    * separation has to come from value. These five surfaces climb monotonically
    * in relative luminance, and the sidebar sits BELOW the page rather than above
    * it: it is chrome, so it recedes and leaves the content card the brightest
    * plane. Keep any new surface on the ladder. */
-  --ga-bg-body:      #0d1417;
-  --ga-bg-container: #151e22;
-  --ga-bg-elevated:  #212d33;
+  --ga-bg-body:      #0a0a0a;
+  --ga-bg-container: #141414;  /* colorBgContainer */
+  --ga-bg-elevated:  #1f1f1f;  /* colorBgElevated */
   /* Lighter than the container here, darker than it in light mode: both mean
    * "one step off the surface". Also feeds el-fill-color, where a hover in dark
    * has to lift rather than sink. */
-  --ga-bg-subtle:    #1c262b;
-  --ga-bg-hover:     rgba(58, 165, 199, 0.10);
+  --ga-bg-subtle:    #1a1a1a;
+  --ga-bg-hover:     rgba(255, 255, 255, 0.08);
 
-  --ga-text-1:        rgba(232, 240, 243, 0.90);
-  --ga-text-2:        rgba(232, 240, 243, 0.66);
-  --ga-text-3:        rgba(232, 240, 243, 0.45);
-  --ga-text-disabled: rgba(232, 240, 243, 0.28);
-  --ga-text-inverse:  #0d1417;
+  --ga-text-1:        rgba(255, 255, 255, 0.85);
+  --ga-text-2:        rgba(255, 255, 255, 0.65);
+  --ga-text-3:        rgba(255, 255, 255, 0.45);
+  --ga-text-disabled: rgba(255, 255, 255, 0.25);
+  --ga-text-inverse:  #0a0a0a;
 
-  --ga-border:       #2a383e;
-  --ga-border-light: #202c31;
+  --ga-border:       #424242;  /* colorBorder */
+  --ga-border-light: #303030;  /* colorBorderSecondary */
 
-  --ga-sidebar-bg:        #070d10;
-  --ga-sidebar-bg-sub:    #05090b;
-  --ga-sidebar-hover:     #16262c;
-  --ga-sidebar-text:      rgba(232, 240, 243, 0.68);
+  --ga-sidebar-bg:        #000c17;
+  --ga-sidebar-bg-sub:    #000710;
+  --ga-sidebar-hover:     #0a2540;
+  --ga-sidebar-text:      rgba(255, 255, 255, 0.65);
   --ga-sidebar-text-active: #ffffff;
   --ga-sidebar-title:     #ffffff;
 
-  --ga-sidebar-light-bg:    #151e22;
-  --ga-sidebar-light-hover: #1b262b;
-  --ga-sidebar-light-title: #e8f0f3;
+  --ga-sidebar-light-bg:    #141414;
+  --ga-sidebar-light-hover: rgba(255, 255, 255, 0.08);
+  --ga-sidebar-light-title: rgba(255, 255, 255, 0.85);
 
   --ga-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.32);
   --ga-shadow:    0 1px 2px rgba(0, 0, 0, 0.32), 0 2px 8px rgba(0, 0, 0, 0.28);

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -150,6 +150,50 @@
 }
 
 /*
+ * ── Sidebar rail ───────────────────────────────────────────────────
+ *
+ * The rail comes in two surfaces, chosen by the themeStyle setting, and both
+ * exist in either colour scheme -- a light rail under the dark scheme is a dark
+ * grey plane, not a white one. Rather than have every rule in styles/sidebar.scss
+ * ask which is active, the layout puts `rail-light` or `rail-dark` on the
+ * container and those rules read these variables.
+ *
+ * That indirection is the point. sidebar.scss used to name --ga-sidebar-* (the
+ * dark set) directly, with !important, so switching themeStyle turned the
+ * container white and left the menu inside it dark -- white text on a white
+ * rail. One name per role, resolved here, is what makes both settings render.
+ */
+.rail-dark {
+  --rail-bg:          var(--ga-sidebar-bg);
+  --rail-bg-sub:      var(--ga-sidebar-bg-sub);
+  --rail-hover:       var(--ga-sidebar-hover);
+  --rail-text:        var(--ga-sidebar-text);
+  --rail-text-active: var(--ga-sidebar-text-active);
+  --rail-title:       var(--ga-sidebar-title);
+  --rail-active-bg:   var(--ga-brand);
+  --rail-active-text: #ffffff;
+  --rail-border:      transparent;
+  --rail-shadow:      2px 0 6px rgba(0, 21, 41, 0.35);
+}
+
+.rail-light {
+  --rail-bg:          var(--ga-sidebar-light-bg);
+  --rail-bg-sub:      var(--ga-sidebar-light-bg);
+  --rail-hover:       var(--ga-sidebar-light-hover);
+  --rail-text:        var(--ga-text-2);
+  --rail-text-active: var(--ga-text-1);
+  --rail-title:       var(--ga-sidebar-light-title);
+  /* Ant Design's controlItemBgActive: the selected row is a tint of the accent,
+   * not a fill of it, so the label stays readable and the rail stays quiet. */
+  --rail-active-bg:   color-mix(in oklab, var(--ga-brand), var(--ga-bg-container) 90%);
+  --rail-active-text: var(--ga-brand);
+  --rail-border:      var(--ga-border-light);
+  /* A hairline does the separating; a drop shadow under a white rail on a
+   * near-white page is a smudge, not an edge. */
+  --rail-shadow:      none;
+}
+
+/*
  * ── Element Plus bridge ────────────────────────────────────────────
  *
  * Element Plus is themed entirely through CSS variables, so pointing its

--- a/tests/e2e/mocked/app-shell.spec.ts
+++ b/tests/e2e/mocked/app-shell.spec.ts
@@ -45,6 +45,48 @@ test.describe('app shell', () => {
     await expect(page.locator('symbol#icon-star')).toBeAttached()
   })
 
+  /**
+   * The logo stays inside the block it is drawn on.
+   *
+   * Both halves of this only appear once the deployment has a logo image and an
+   * application name long enough to fill the sidebar -- which the demo has and
+   * the fixture did not, so the layout could break in production while every
+   * test stayed green. Branding is fetched on the login page and cached, so a
+   * session that resumes straight into an inner page reads it from storage,
+   * which is what this seeds.
+   */
+  test('the sidebar logo is not pushed out of its header', async({ page, context }) => {
+    await authenticate(context)
+    await installApiMocks(page)
+
+    const logo = 'data:image/svg+xml;base64,' + Buffer.from(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><rect width="64" height="64" fill="#22c55e"/></svg>'
+    ).toString('base64')
+
+    await page.addInitScript(([name, src]) => {
+      localStorage.setItem('app_info', JSON.stringify({ sys_app_name: name, sys_app_logo: src }))
+    }, ['go-admin管理系统', logo])
+
+    await page.goto('/#/demo/product')
+    await page.waitForSelector('.el-menu')
+
+    const header = await page.locator('.sidebar-logo-container').boundingBox()
+    const image = await page.locator('.sidebar-logo').boundingBox()
+    expect(header, 'the logo header is rendered').toBeTruthy()
+    expect(image, 'the logo image is rendered').toBeTruthy()
+
+    // The header clips its overflow, so anything outside it is not merely
+    // misplaced -- it is cut in half, which is how this last shipped.
+    expect(image!.y).toBeGreaterThanOrEqual(header!.y)
+    expect(image!.y + image!.height).toBeLessThanOrEqual(header!.y + header!.height)
+    expect(image!.x).toBeGreaterThanOrEqual(header!.x)
+
+    // Centred, not merely contained: off by more than a pixel means the row is
+    // laid out by something other than the rule that was written for it.
+    const offset = (image!.y - header!.y) - (header!.height - image!.height) / 2
+    expect(Math.abs(offset)).toBeLessThanOrEqual(1)
+  })
+
   test('builds the sidebar from the backend menu', async({ page, context }) => {
     await authenticate(context)
     const { calls } = await installApiMocks(page)

--- a/tests/e2e/mocked/sidebar-rail.spec.ts
+++ b/tests/e2e/mocked/sidebar-rail.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+import { authenticate, installApiMocks } from './fixtures'
+
+/**
+ * Both sidebar surfaces render.
+ *
+ * The light rail used to be a setting that did not work: the container turned
+ * white while styles/sidebar.scss held the menu inside it to the dark tokens
+ * with !important, so the rows kept their white text and landed white on white.
+ * Every test stayed green throughout, because nothing looked at what a menu row
+ * renders as -- it was present, it was clickable, it just could not be read.
+ *
+ * So these measure contrast rather than colour. Asserting the expected hex would
+ * pin the palette instead of the property that matters, and would need
+ * rewriting the next time the brand changes; a ratio keeps working.
+ */
+
+/** Relative luminance per WCAG 2.1, from a computed `rgb()` string. */
+const luminance = (colour: string): number => {
+  const [r, g, b] = colour.match(/[\d.]+/g)!.slice(0, 3).map(Number)
+  const channel = (v: number) => {
+    const s = v / 255
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4
+  }
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+}
+
+const contrast = (a: string, b: string): number => {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x)
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+interface RailColours {
+  rowText: string
+  rowBg: string
+  railBg: string
+  titleText: string
+  headerBg: string
+}
+
+const railColours = (page: Page): Promise<RailColours> => page.evaluate(() => {
+  const at = (selector: string) => document.querySelector(selector) as HTMLElement
+  const row = at('.el-menu-item:not(.is-active)')
+  return {
+    rowText: getComputedStyle(row).color,
+    rowBg: getComputedStyle(row).backgroundColor,
+    railBg: getComputedStyle(at('.sidebar-container')).backgroundColor,
+    titleText: getComputedStyle(at('.sidebar-title')).color,
+    headerBg: getComputedStyle(at('.sidebar-logo-container')).backgroundColor
+  }
+})
+
+const open = async(page: Page) => {
+  // The name comes from the login page and is cached; seeding it means the
+  // header has something to render.
+  await page.addInitScript(() => {
+    localStorage.setItem('app_info', JSON.stringify({ sys_app_name: 'go-admin管理系统' }))
+  })
+  await page.goto('/#/demo/product')
+  await page.waitForSelector('.el-menu')
+}
+
+/** Flips the rail through the settings drawer, the way a user would. */
+const switchRail = async(page: Page, to: 'light' | 'dark') => {
+  await page.locator('#layout-settings').click()
+  await expect(page.locator('.rightPanel-container')).toHaveClass(/show/)
+  await page.locator(`.setting-drawer-block-checbox-item:has(img[alt="${to}"])`).click()
+  await page.locator('.rightPanel-close').click()
+}
+
+test.describe('sidebar rail', () => {
+  test.beforeEach(async({ page, context }) => {
+    await authenticate(context)
+    await installApiMocks(page)
+  })
+
+  test('a menu row is legible on the default rail', async({ page }) => {
+    await open(page)
+
+    const c = await railColours(page)
+    // 4.5:1 is WCAG AA for body text. A row that fails this is the bug: the
+    // colours were still applied, they just cancelled each other out.
+    expect(contrast(c.rowText, c.rowBg), `row text ${c.rowText} on ${c.rowBg}`).toBeGreaterThan(4.5)
+  })
+
+  test('the application name is legible on the rail header', async({ page }) => {
+    await open(page)
+
+    const c = await railColours(page)
+    expect(contrast(c.titleText, c.headerBg), `title ${c.titleText} on ${c.headerBg}`).toBeGreaterThan(4.5)
+  })
+
+  test('the header is part of the rail, not a block of brand colour on it', async({ page }) => {
+    await open(page)
+
+    const c = await railColours(page)
+    // These used to differ by a full-saturation gradient, which is what made the
+    // corner read as a plaque stuck onto the navigation rather than its header.
+    expect(c.headerBg).toBe(c.railBg)
+    expect(c.rowBg).toBe(c.railBg)
+  })
+
+  test('the other rail is legible too, and the switch reaches it', async({ page }) => {
+    await open(page)
+    const before = await railColours(page)
+
+    await switchRail(page, 'dark')
+
+    const after = await railColours(page)
+    expect(after.railBg, 'the rail actually changed').not.toBe(before.railBg)
+    expect(contrast(after.rowText, after.rowBg), `row text ${after.rowText} on ${after.rowBg}`).toBeGreaterThan(4.5)
+    expect(contrast(after.titleText, after.headerBg), `title ${after.titleText} on ${after.headerBg}`).toBeGreaterThan(4.5)
+    expect(after.headerBg).toBe(after.railBg)
+  })
+})


### PR DESCRIPTION
Started as "the theme colour looks bad" and "is the top-left corner broken". It was, and two more things were broken behind it.

## The corner

With a logo image configured and an application name long enough to fill the rail — which the demo has — the image was laid out at `y=50` inside a 64px header and cut in half by its `overflow: hidden`.

The header lays that row out with flex. It never applied. `styles/sidebar.scss` is nested under `#app`, so a bare `a` rule inside it carried an **id's specificity** and beat the component's scoped `display: flex` — one id outranks any number of classes. The logo link is absolutely positioned, which blockifies `inline-block`, so it computed to `block`, `align-items` and `justify-content` went inert, and a 28px image landed on the baseline of a 64px line box.

```
container  y=0   h=64        ← clips its overflow
image      y=50  h=28        ← 50..78, so 14px of it was cut off
```

That rule is from the template this sidebar started as, where menu rows were wrapped in links. Element Plus renders rows as `<li>`, so the **only** anchor left in the sidebar is the logo link: the one element the rule reaches, and the one it breaks. Both of its effects are covered elsewhere, so it goes rather than the logo's specificity going up — that would leave it to break the next anchor added here.

## The palette

`#0d7d9e` was picked to be "distinct from the Ant Design blue that most admin templates ship with". That distinction is worth less here than being predictable: this is a framework other people build admin panels on.

It also meant the application had **two** palettes. `index.html`'s first-paint loader has always used navy `#0b1f3a` with Ant blue `#1677ff`, so every page load flashed blue and then settled into teal. Moving to Ant's palette makes them agree, and costs nothing to maintain.

| | before | after | |
|---|---|---|---|
| brand | `#0d7d9e` | `#1677ff` | colorPrimary |
| success | `#16a34a` | `#52c41a` | |
| warning | `#d97706` | `#faad14` | |
| error | `#dc2626` | `#ff4d4f` | |
| neutrals | teal-black | pure black, true greys | the tint read as green beside blue |
| rail | `#0f2b35` | `#001529` | the navy Ant Design Pro uses |

Only the base values change — every tint, fill and border is derived from them with `color-mix`, which is what that arrangement was for.

## The light sidebar, which had never worked

Choosing it turned the container white and left everything inside it dark. The rows kept their white text, so the menu rendered **white on white** — present, clickable, unreadable.

Three places pinned the dark colours where no setting could reach them:

| | |
|---|---|
| `styles/sidebar.scss` | twelve rules naming the dark tokens with `!important`, beating the theme props the component passes to `el-menu` |
| `SidebarItem.vue` | `:style="{ backgroundColor: '#000c17' }"` — a literal inline on the submenu wrapper, which nothing can override |
| `Logo.vue` | a brand-colour gradient behind the header |

They are now one set of `--rail-*` custom properties resolved by a `rail-light` / `rail-dark` class the layout puts on the container. `el-menu`'s `background-color` and `text-color` props go with them: Element Plus turns those into inline styles the stylesheet then has to out-`!important`, which is how this broke in the first place.

**Light is now the default**, matching Ant Design Pro: navigation and content on one plane separated by a hairline, with the accent spent on the few things that are actually interactive rather than on the largest block of screen nobody looks at. The dark rail is one switch away and is covered by the same tests.

The header also stops being a brand-colour gradient. It put the most saturated block in the interface against the darkest one and read as a plaque stuck onto the navigation rather than as its header.

## The tests measure contrast, not colour

Asserting hex values would pin the palette instead of the property that matters, and would need rewriting at every rebrand. A ratio keeps working.

Both bugs were counter-proved — restoring the old code turns the new tests red, with the failure printing the bug:

```
the sidebar logo is not pushed out of its header
  Expected: <= 64
  Received:    78

a menu row is legible on the default rail
  Error: row text rgb(255, 255, 255) on rgb(255, 255, 255)
```

Five tests: containment and centring of the logo, WCAG AA contrast for a menu row and for the application name, the header being part of the rail rather than a block on it, and the same checks again after switching rails through the settings drawer — so the switch itself is covered, not just the default.

## Verification

lint 0 errors (29 pre-existing warnings) · type-check clean · unit 220 · e2e 131 · `build:prod` ok. Each of the three commits builds on its own.

## Not done here

- **Dark mode has no way in.** Nothing in the repository adds the `dark` class to `<html>`, so the `.dark` token block and Element Plus's dark css-vars have been maintained without ever rendering. Forced on by hand it looks right, which is worth keeping — but with no switch, nobody would notice when it stops.
- **127 literal colours in application chrome, across 37 files**, that should read from tokens. An audit of `src/` found 398 literals in total, but most are legitimately literal: SVG artwork, ECharts categorical palettes, the colour picker's preset list. Worth doing after there is a dark-mode switch, which is what would show which of them actually break.
