### PR TITLE
feat: add a light and dark switch, and make the dark palette reachable

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,13 +27,22 @@
   <meta name="description"
     content="基于Gin + Vue + Element UI的前后端分离权限管理系统，初始化极度简单，只需要配置文件中，修改数据库连接，系统启动后会自动初始化数据库信息以及必须的基础数据">
   <style>
+    /* 这两个值必须与 styles/tokens.css 的 --ga-bg-body 一致。写在这里是因为
+       首屏在样式表加载之前就要有底色；改 token 时要一起改。
+       深色分支靠上面那段脚本加的 .dark 生效，所以不会闪一帧浅色。 */
     html,
     body,
     #app {
       height: 100%;
       margin: 0px;
       padding: 0px;
-      background: #f0f1f5;
+      background: #f5f5f5;
+    }
+
+    html.dark,
+    html.dark body,
+    html.dark #app {
+      background: #0a0a0a;
     }
 
     /* ============ 首屏加载 ============

--- a/index.html
+++ b/index.html
@@ -8,6 +8,21 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <link rel="icon" href="/favicon.ico">
   <title>go-admin</title>
+  <!-- ============ 配色方案 ============
+       在解析任何 CSS 之前决定明暗，否则存了 dark 偏好的用户会先看到一帧亮色。
+       只能写在这里：模块脚本一律是 defer 的，跑起来时首屏已经画完了。
+       规则与 src/utils/color-scheme.ts 一致，两处读同一个键，改一处要改两处。 -->
+  <script>
+    (function () {
+      try {
+        var stored = localStorage.getItem('color-scheme')
+        var dark = stored === 'dark' ||
+          ((stored === 'system' || !stored) &&
+            window.matchMedia && matchMedia('(prefers-color-scheme: dark)').matches)
+        if (dark) document.documentElement.classList.add('dark')
+      } catch (e) { /* 隐私模式下 localStorage 会抛，主题不值得为此让页面挂掉 */ }
+    })()
+  </script>
   <meta name="keywords" content="go-admin,gin,权限管理系统,gin-admin,gin-vue-admin,go">
   <meta name="description"
     content="基于Gin + Vue + Element UI的前后端分离权限管理系统，初始化极度简单，只需要配置文件中，修改数据库连接，系统启动后会自动初始化数据库信息以及必须的基础数据">

--- a/src/components/ChartCard/index.vue
+++ b/src/components/ChartCard/index.vue
@@ -40,7 +40,9 @@ export default {
     title: { type: String, default: '' },
     total: { type: [Function, Number, String], required: false, default: null },
     loading: { type: Boolean, default: false },
-    color: { type: String, default: '#1677ff' }
+    // Falls back to the brand token rather than a copy of its value, so a
+    // rebrand does not leave this one card behind.
+    color: { type: String, default: 'var(--ga-brand)' }
   }
 }
 </script>
@@ -58,7 +60,7 @@ export default {
     top: 0;
     bottom: 0;
     width: 4px;
-    background-color: var(--kpi-color, #1677ff);
+    background-color: var(--kpi-color, var(--ga-brand));
     z-index: 1;
     border-radius: 4px 0 0 4px;
   }
@@ -75,7 +77,7 @@ export default {
   right: 16px;
   font-size: 56px;
   opacity: 0.1;
-  color: var(--kpi-color, #1677ff);
+  color: var(--kpi-color, var(--ga-brand));
   line-height: 1;
   pointer-events: none;
   z-index: 0;
@@ -90,7 +92,7 @@ export default {
     position: relative;
     overflow: hidden;
     width: 100%;
-    color: rgba(0, 0, 0, .45);
+    color: var(--ga-text-3);
     font-size: 14px;
     line-height: 22px;
   }
@@ -115,7 +117,7 @@ export default {
     overflow: hidden;
     text-overflow: ellipsis;
     margin: 0;
-    color: rgba(0, 0, 0, .65);
+    color: var(--ga-text-2);
     font-size: 14px;
   }
 }
@@ -139,7 +141,7 @@ export default {
   text-overflow: ellipsis;
   word-break: break-all;
   white-space: nowrap;
-  color: rgba(0, 0, 0, 0.85);
+  color: var(--ga-text-1);
   margin-top: 4px;
   margin-bottom: 0;
   font-size: 28px;

--- a/src/components/RankList/index.vue
+++ b/src/components/RankList/index.vue
@@ -36,7 +36,7 @@ export default {
   .title {
     font-size: 14px;
     font-weight: 600;
-    color: rgba(0, 0, 0, 0.85);
+    color: var(--ga-text-1);
     margin-bottom: 0;
   }
 
@@ -63,10 +63,11 @@ export default {
     font-size: 12px;
     font-weight: 600;
     margin-right: 16px;
-    background: #f0f0f0;
-    color: #8c8c8c;
+    background: var(--ga-bg-hover);
+    color: var(--ga-text-2);
 
     &.rank-gold {
+      // Gold, silver and bronze stay literal: they encode rank, not theme.
       background: linear-gradient(135deg, #ffe58f, #faad14);
       color: #fff;
     }
@@ -84,7 +85,7 @@ export default {
 
   .rank-name {
     flex: 1;
-    color: rgba(0, 0, 0, .65);
+    color: var(--ga-text-2);
     font-size: 14px;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -93,7 +94,7 @@ export default {
 
   .rank-total {
     flex-shrink: 0;
-    color: rgba(0, 0, 0, .85);
+    color: var(--ga-text-1);
     font-size: 14px;
     font-weight: 500;
     margin-left: 8px;

--- a/src/layout/components/Settings/index.vue
+++ b/src/layout/components/Settings/index.vue
@@ -35,6 +35,17 @@
           <span>主题颜色</span>
           <theme-picker style="float: right;height: 26px;margin: -3px 8px 0 0;" @change="themeChange" />
         </div>
+
+        <!-- 明暗配色。与上面的「侧栏风格」是两个维度：这里决定整个界面，
+             那里只决定侧栏那一条。跟随系统是默认值，也是唯一会随系统变的选项。 -->
+        <div class="drawer-item">
+          <span>明暗配色</span>
+          <el-radio-group v-model="colorScheme" size="small" class="drawer-color-scheme">
+            <el-radio-button value="system">跟随系统</el-radio-button>
+            <el-radio-button value="light">浅色</el-radio-button>
+            <el-radio-button value="dark">深色</el-radio-button>
+          </el-radio-group>
+        </div>
       </div>
       <el-divider />
       <div class="setting-drawer-content">
@@ -97,6 +108,7 @@ export default {
     fixedHeader: settingModel('fixedHeader'),
     tagsView: settingModel('tagsView'),
     sidebarLogo: settingModel('sidebarLogo'),
+    colorScheme: settingModel('colorScheme'),
     topNav: {
       get() {
         return useSettingsStore().topNav
@@ -131,13 +143,13 @@ export default {
 
   .drawer-title {
     margin-bottom: 12px;
-    color: rgba(0, 0, 0, .85);
+    color: var(--ga-text-1);
     font-size: 14px;
     line-height: 22px;
   }
 
   .drawer-item {
-    color: rgba(0, 0, 0, .65);
+    color: var(--ga-text-2);
     font-size: 14px;
     padding: 12px 0;
   }
@@ -145,11 +157,18 @@ export default {
   .drawer-switch {
     float: right
   }
+
+  // The three-way control is wider than a switch, so it goes on its own line
+  // rather than being crushed against the label at 300px of drawer.
+  .drawer-color-scheme {
+    display: flex;
+    margin-top: 8px;
+  }
 }
 .setting-drawer-content{
   .setting-drawer-title{
     margin-bottom: 12px;
-    color: rgba(0,0,0,.85);
+    color: var(--ga-text-1);
     font-size: 14px;
     line-height: 22px;
     font-weight: bold;
@@ -175,7 +194,7 @@ export default {
             height: 100%;
             padding-top: 15px;
             padding-left: 24px;
-            color: #1890ff;
+            color: var(--ga-brand);
             font-weight: 700;
             font-size: 14px;
         }

--- a/src/settings.js
+++ b/src/settings.js
@@ -50,4 +50,14 @@ export default {
    * prefer it, and both are covered by tests/e2e/mocked/sidebar-rail.spec.ts.
    */
   themeStyle: 'light'
+
+  /**
+   * Light and dark are NOT set here.
+   *
+   * The colour scheme is seeded from localStorage by the store, because a
+   * snippet in index.html has already painted the page from that same value
+   * before any of this module loads -- a default here would only be able to
+   * disagree with what is on screen. src/utils/color-scheme.ts owns it, and
+   * its own default is 'system'.
+   */
 }

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,6 +1,8 @@
 import { defineStore } from 'pinia'
 import variables from '@/styles/element-variables.module.scss'
 import defaultSettings from '@/settings'
+import { applyColorScheme, initColorScheme } from '@/utils/color-scheme'
+import type { ColorScheme } from '@/utils/color-scheme'
 
 const { showSettings, topNav, tagsView, fixedHeader, sidebarLogo, themeStyle } = defaultSettings
 
@@ -13,6 +15,7 @@ export type SettingKey =
   | 'fixedHeader'
   | 'sidebarLogo'
   | 'themeStyle'
+  | 'colorScheme'
 
 /**
  * Layout preferences driven by the right-hand settings drawer.
@@ -28,7 +31,17 @@ export const useSettingsStore = defineStore('settings', {
     tagsView,
     fixedHeader,
     sidebarLogo,
-    themeStyle
+    /** Rail surface: light or dark. Not the same axis as colorScheme below. */
+    themeStyle,
+    /**
+     * Light, dark or follow the OS.
+     *
+     * Seeded from what is stored rather than from defaultSettings, because the
+     * snippet in index.html has already painted the page from that same value
+     * -- reading anything else here would leave the drawer disagreeing with
+     * what is on screen. src/utils/color-scheme.ts owns the rules.
+     */
+    colorScheme: initColorScheme()
   }),
 
   actions: {
@@ -37,6 +50,12 @@ export const useSettingsStore = defineStore('settings', {
      * closed set — same guard the Vuex mutation had via hasOwnProperty.
      */
     changeSetting({ key, value }: { key: SettingKey, value: unknown }) {
+      if (key === 'colorScheme') {
+        // The only setting with an effect outside the store: it puts the class
+        // on <html> and remembers the choice.
+        applyColorScheme(value as ColorScheme)
+      }
+
       if (Object.prototype.hasOwnProperty.call(this.$state, key)) {
         // Object.assign rather than indexed assignment: the key is validated at
         // runtime above, and a union-typed index cannot be narrowed for writes.

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -23,8 +23,10 @@
   /* ── Brand ────────────────────────────────────────────────────────
    * Change this one value to retheme the application.
    *
-   * Ant Design 5's colorPrimary. The palette below follows the rest of that
-   * system too, because this is a framework other people build admin panels on
+   * Ant Design's colorPrimary, verified against antd 6.6.1's computed design
+   * tokens rather than copied from a blog post. The palette below follows the
+   * rest of that system too, because this is a framework people build admin
+   * panels on
    * and the least surprising thing it can look like is the one every Chinese
    * admin panel already looks like. It is also what index.html's first-paint
    * loader has always used, so the two finally agree.
@@ -36,7 +38,7 @@
   --ga-mix-toward: #ffffff;
 
   /* ── Semantic colours ─────────────────────────────────────────
-   * Ant Design 5's success / warning / error. Brighter than the Tailwind ramp
+   * antd 6's success / warning / error seed tokens. Brighter than the Tailwind ramp
    * they replace, which is the point: a status column is read at a glance and
    * these separate at small sizes. */
   --ga-success: #52c41a;
@@ -45,7 +47,7 @@
   --ga-info:    #8c8c8c;
 
   /* ── Neutrals ──────────────────────────────────────────────────
-   * Ant Design 5's neutral ramp, which is achromatic: text is black at four
+   * antd 6's neutral ramp, which is achromatic: text is black at four
    * opacities, surfaces are true greys. These used to carry a slight brand tint
    * so they would "read as chosen"; next to a blue accent that tint is what
    * made the greys look faintly green instead.
@@ -100,7 +102,7 @@
 }
 
 .dark {
-  /* Ant Design 5's dark algorithm: the same hues, pulled down so they do not
+  /* antd 6's darkAlgorithm output: the same hues, pulled down so they do not
    * glare on a black ground. */
   --ga-brand: #1668dc;
   --ga-mix-toward: #000000;
@@ -115,6 +117,9 @@
    * in relative luminance, and the sidebar sits BELOW the page rather than above
    * it: it is chrome, so it recedes and leaves the content card the brightest
    * plane. Keep any new surface on the ladder. */
+  /* antd's colorBgLayout is #000000 here. The ladder above needs room *below*
+   * the page for the rail, and pure black leaves none, so this stops one step
+   * short. The only value on this list that is deliberately not antd's. */
   --ga-bg-body:      #0a0a0a;
   --ga-bg-container: #141414;  /* colorBgContainer */
   --ga-bg-elevated:  #1f1f1f;  /* colorBgElevated */

--- a/src/utils/color-scheme.ts
+++ b/src/utils/color-scheme.ts
@@ -1,0 +1,82 @@
+/**
+ * Light or dark, and the one place that decides which.
+ *
+ * The dark palette has existed in styles/tokens.css for a while, as has Element
+ * Plus's dark variable sheet, but nothing ever put the `dark` class on <html> --
+ * so the whole thing was maintained without ever rendering. This is the switch.
+ *
+ * Three values, not two. `system` follows the operating system and keeps
+ * following it, which is what a preference the user never set should do;
+ * `light` and `dark` are a deliberate choice and stop following.
+ *
+ * The class is applied twice on purpose. A snippet in index.html sets it before
+ * the first byte of CSS is parsed, because a stored `dark` preference would
+ * otherwise show a frame of the light theme; this module then owns it for the
+ * rest of the session. Both read the same key and the same rules, so they cannot
+ * disagree -- keep them in step if either changes.
+ */
+
+export type ColorScheme = 'system' | 'light' | 'dark'
+
+/** Also read by the snippet in index.html. */
+export const STORAGE_KEY = 'color-scheme'
+
+const DARK_CLASS = 'dark'
+
+const isScheme = (value: unknown): value is ColorScheme =>
+  value === 'system' || value === 'light' || value === 'dark'
+
+/** What was stored, or `system` for anything unset or unrecognised. */
+export const storedScheme = (): ColorScheme => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    return isScheme(stored) ? stored : 'system'
+  } catch {
+    // Safari in private mode throws on localStorage; a theme is not worth a
+    // crash on boot.
+    return 'system'
+  }
+}
+
+const prefersDark = (): boolean =>
+  typeof matchMedia === 'function' && matchMedia('(prefers-color-scheme: dark)').matches
+
+/** Whether a scheme renders dark right now. Only `system` depends on the OS. */
+export const resolvesDark = (scheme: ColorScheme): boolean =>
+  scheme === 'dark' || (scheme === 'system' && prefersDark())
+
+const paint = (scheme: ColorScheme): void => {
+  document.documentElement.classList.toggle(DARK_CLASS, resolvesDark(scheme))
+}
+
+/**
+ * Applies a scheme and remembers it.
+ *
+ * Storage failing is not a reason to leave the page in the wrong colours, so the
+ * class is set either way.
+ */
+export const applyColorScheme = (scheme: ColorScheme): void => {
+  paint(scheme)
+  try {
+    localStorage.setItem(STORAGE_KEY, scheme)
+  } catch { /* see storedScheme */ }
+}
+
+/**
+ * Applies what is stored and keeps `system` in step with the OS.
+ *
+ * Called once at startup. The listener is never removed: it lives as long as the
+ * document, and re-reads the stored value on each change so it stops mattering
+ * the moment the user picks a side.
+ */
+export const initColorScheme = (): ColorScheme => {
+  const scheme = storedScheme()
+  paint(scheme)
+
+  if (typeof matchMedia === 'function') {
+    matchMedia('(prefers-color-scheme: dark)')
+      .addEventListener('change', () => paint(storedScheme()))
+  }
+
+  return scheme
+}

--- a/src/views/dashboard/admin/index.vue
+++ b/src/views/dashboard/admin/index.vue
@@ -136,7 +136,10 @@ export default {
 <style lang="scss" scoped>
 .dashboard-editor-container {
   padding: 12px;
-  background-color: #f0f2f5;
+  // The page's own plane, so it has to be the page's own colour. This was
+  // #f0f2f5, which stayed light under the dark scheme and put every card on
+  // this page on a white sheet.
+  background-color: var(--ga-bg-body);
   position: relative;
 }
 

--- a/src/views/error-page/404.vue
+++ b/src/views/error-page/404.vue
@@ -10,7 +10,7 @@
       <div class="bullshit">
         <div class="bullshit__oops">OOPS!</div>
         <div class="bullshit__info">All rights reserved
-          <a style="color:#20a0ff" href="https://wallstreetcn.com" target="_blank">wallstreetcn</a>
+          <a style="color:var(--ga-brand)" href="https://wallstreetcn.com" target="_blank">wallstreetcn</a>
         </div>
         <div class="bullshit__headline">{{ message }}</div>
         <div class="bullshit__info">Please check that the URL you entered is correct, or click the button below to return to the homepage.</div>
@@ -175,7 +175,7 @@ export default {
     &__headline {
       font-size: 20px;
       line-height: 24px;
-      color: #222;
+      color: var(--ga-text-1);
       font-weight: bold;
       opacity: 0;
       margin-bottom: 10px;

--- a/tests/e2e/mocked/color-scheme.spec.ts
+++ b/tests/e2e/mocked/color-scheme.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+import { authenticate, installApiMocks } from './fixtures'
+
+/**
+ * The light/dark switch, and the two places that have to agree about it.
+ *
+ * The dark palette and Element Plus's dark variable sheet were both in the tree
+ * for a long time with nothing to turn them on -- no code anywhere put the
+ * `dark` class on <html> -- so they were maintained without ever rendering.
+ * These tests exist so that cannot happen again quietly.
+ *
+ * The awkward part is that the decision is made twice: a snippet in index.html
+ * paints before any CSS parses, and src/utils/color-scheme.ts owns it from then
+ * on. They read the same key and the same rules, and the test that matters most
+ * here is the one that checks they do not disagree.
+ */
+
+const KEY = 'color-scheme'
+
+const luminance = (colour: string): number => {
+  const [r, g, b] = colour.match(/[\d.]+/g)!.slice(0, 3).map(Number)
+  const channel = (v: number) => {
+    const s = v / 255
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4
+  }
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+}
+
+const surfaces = (page: Page) => page.evaluate(() => ({
+  hasDarkClass: document.documentElement.classList.contains('dark'),
+  body: getComputedStyle(document.body).backgroundColor,
+  container: getComputedStyle(document.querySelector('.app-main') ?? document.body).backgroundColor,
+  text: getComputedStyle(document.body).color
+}))
+
+const open = async(page: Page, stored?: string) => {
+  await page.addInitScript(value => {
+    localStorage.setItem('app_info', JSON.stringify({ sys_app_name: 'go-admin管理系统' }))
+    if (value) localStorage.setItem('color-scheme', value)
+  }, stored ?? '')
+  await page.goto('/#/demo/product')
+  await page.waitForSelector('.el-table')
+}
+
+test.describe('colour scheme', () => {
+  test.beforeEach(async({ page, context }) => {
+    await authenticate(context)
+    await installApiMocks(page)
+  })
+
+  test('a stored dark preference is applied before anything renders', async({ page }) => {
+    await open(page, 'dark')
+
+    const s = await surfaces(page)
+    expect(s.hasDarkClass).toBe(true)
+    // The point of the snippet in index.html: the class is on <html> from the
+    // first parsed byte, not after the bundle boots.
+    expect(luminance(s.body), `body ${s.body}`).toBeLessThan(0.1)
+  })
+
+  test('index.html and the token file agree about the page background', async({ page }) => {
+    // index.html carries its own copy of the body colour, because the page needs
+    // one before the stylesheet exists. A copy can drift: this one held
+    // #f0f1f5 -- the previous palette's grey -- long after the tokens moved on,
+    // and had no dark branch at all, so dark mode kept a light page under it.
+    await open(page, 'dark')
+    const dark = await page.evaluate(() => ({
+      body: getComputedStyle(document.body).backgroundColor,
+      token: getComputedStyle(document.documentElement).getPropertyValue('--ga-bg-body').trim()
+    }))
+    expect(dark.body).toBe(await page.evaluate(t => {
+      const probe = document.createElement('div')
+      probe.style.backgroundColor = t
+      document.body.append(probe)
+      const resolved = getComputedStyle(probe).backgroundColor
+      probe.remove()
+      return resolved
+    }, dark.token))
+  })
+
+  test('a stored light preference stays light', async({ page }) => {
+    await open(page, 'light')
+
+    const s = await surfaces(page)
+    expect(s.hasDarkClass).toBe(false)
+    expect(luminance(s.body), `body ${s.body}`).toBeGreaterThan(0.7)
+  })
+
+  test('the drawer switches the scheme and the choice survives a reload', async({ page }) => {
+    await open(page)
+
+    await page.locator('#layout-settings').click()
+    await expect(page.locator('.rightPanel-container')).toHaveClass(/show/)
+    await page.locator('.drawer-color-scheme').getByText('深色', { exact: true }).click()
+
+    await expect.poll(async() => (await surfaces(page)).hasDarkClass).toBe(true)
+    expect(await page.evaluate(k => localStorage.getItem(k), KEY)).toBe('dark')
+
+    // Remembered, not just applied: a preference that resets on reload is worse
+    // than none, because the page flashes the theme the user rejected.
+    await page.reload()
+    await page.waitForSelector('.el-table')
+    expect((await surfaces(page)).hasDarkClass).toBe(true)
+  })
+
+  test('an unset preference follows the operating system', async({ page, browser }) => {
+    await open(page)
+    // Nothing stored, and this context reports a light OS
+    expect((await surfaces(page)).hasDarkClass).toBe(false)
+
+    const dark = await browser.newContext({ colorScheme: 'dark' })
+    const darkPage = await dark.newPage()
+    await authenticate(dark)
+    await installApiMocks(darkPage)
+    await darkPage.goto('/#/demo/product')
+    await darkPage.waitForSelector('.el-table')
+
+    expect(await darkPage.evaluate(() =>
+      document.documentElement.classList.contains('dark')
+    )).toBe(true)
+    await dark.close()
+  })
+})

--- a/tests/e2e/mocked/dark-mode-audit.spec.ts
+++ b/tests/e2e/mocked/dark-mode-audit.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+import { authenticate, installApiMocks } from './fixtures'
+
+/**
+ * Walks the pages in the dark scheme and fails on anything still painted light.
+ *
+ * This replaces the way that used to be checked, which was to grep for hex
+ * literals. That over-counts by more than an order of magnitude: `src` holds
+ * around four hundred of them, and on the routes below exactly two were
+ * rendering wrong. Most literals are behind a rule something else overrides, or
+ * belong to artwork, or are a chart's categorical palette -- all fine, and all
+ * indistinguishable from a real break in a grep.
+ *
+ * What is checkable is the rendered result, which is what this does: for every
+ * box big enough to be seen, is its background light while the scheme is dark,
+ * and is its text legible against whatever is actually behind it.
+ *
+ * It is a floor, not a ceiling. Only routes the fixture can reach are visited,
+ * and a page nobody lists here is a page nobody is checking -- so add to
+ * ROUTES rather than assuming the sweep covers a new screen.
+ */
+
+const ROUTES = [
+  '/#/dashboard',
+  '/#/admin/sys-api',
+  '/#/admin/sys-user',
+  '/#/admin/sys-dept',
+  '/#/demo/product',
+  '/#/schedule/log',
+  '/#/profile',
+  '/#/404'
+]
+
+/** Anything lighter than this counts as a light surface. Mid-grey is ~0.21. */
+const LIGHT = 0.55
+
+/** WCAG AA for large text. Body text wants 4.5; this is the floor for "visible". */
+const MIN_CONTRAST = 3
+
+const audit = (page: Page) => page.evaluate(({ light, minContrast }) => {
+  const luminance = (colour: string): number | null => {
+    const parts = colour.match(/[\d.]+/g)
+    if (!parts) return null
+    const [r, g, b, alpha = '1'] = parts
+    // A transparent surface is not this element's problem; keep walking up.
+    if (Number(alpha) < 0.4) return null
+    const channel = (v: number) => {
+      const s = v / 255
+      return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4
+    }
+    return 0.2126 * channel(+r) + 0.7152 * channel(+g) + 0.0722 * channel(+b)
+  }
+
+  /** The first opaque background at or above an element -- what it sits on. */
+  const behind = (el: HTMLElement): number => {
+    for (let n: HTMLElement | null = el; n; n = n.parentElement) {
+      const value = luminance(getComputedStyle(n).backgroundColor)
+      if (value !== null) return value
+    }
+    return 0
+  }
+
+  const describe = (el: HTMLElement) => el.tagName.toLowerCase() +
+    (typeof el.className === 'string' && el.className
+      ? '.' + el.className.trim().split(/\s+/).slice(0, 2).join('.') : '')
+
+  const surfaces: string[] = []
+  const texts: string[] = []
+
+  for (const el of Array.from(document.querySelectorAll<HTMLElement>('body *'))) {
+    const box = el.getBoundingClientRect()
+    if (box.width < 60 || box.height < 16) continue
+
+    const own = luminance(getComputedStyle(el).backgroundColor)
+    if (own !== null && own > light) surfaces.push(`${describe(el)} bg=${getComputedStyle(el).backgroundColor}`)
+
+    // Leaf text only: a wrapper's colour is not what the reader sees.
+    if (!el.textContent?.trim() || el.children.length) continue
+    // Disabled controls are low-contrast on purpose.
+    if (el.closest('.is-disabled, [disabled]')) continue
+
+    const foreground = luminance(getComputedStyle(el).color)
+    if (foreground === null) continue
+    const [hi, lo] = [foreground, behind(el)].sort((a, b) => b - a)
+    const ratio = (hi + 0.05) / (lo + 0.05)
+    if (ratio < minContrast) {
+      texts.push(`${describe(el)} "${el.textContent.trim().slice(0, 24)}" ${ratio.toFixed(2)}:1`)
+    }
+  }
+
+  return { surfaces: [...new Set(surfaces)], texts: [...new Set(texts)] }
+}, { light: LIGHT, minContrast: MIN_CONTRAST })
+
+test.describe('dark scheme', () => {
+  test('no page is still painted light', async({ page, context }) => {
+    await authenticate(context)
+    await installApiMocks(page)
+    await page.addInitScript(() => {
+      localStorage.setItem('color-scheme', 'dark')
+      localStorage.setItem('app_info', JSON.stringify({ sys_app_name: 'go-admin管理系统' }))
+    })
+    await page.setViewportSize({ width: 1280, height: 800 })
+
+    const broken: string[] = []
+    for (const route of ROUTES) {
+      await page.goto(route)
+      // No single selector fits every page here, and a missing wait shows up as
+      // an empty audit rather than a failure, so this settles on time.
+      await page.waitForTimeout(1500)
+
+      const { surfaces, texts } = await audit(page)
+      for (const hit of surfaces) broken.push(`${route}  light surface: ${hit}`)
+      for (const hit of texts) broken.push(`${route}  unreadable text: ${hit}`)
+    }
+
+    expect(broken, `\n${broken.join('\n')}\n`).toEqual([])
+  })
+})

--- a/tests/e2e/mocked/sidebar-rail.spec.ts
+++ b/tests/e2e/mocked/sidebar-rail.spec.ts
@@ -51,6 +51,26 @@ const railColours = (page: Page): Promise<RailColours> => page.evaluate(() => {
   }
 })
 
+/**
+ * Waits for the rail's colours to stop moving.
+ *
+ * Element Plus transitions a menu row's background and text over 300ms, and
+ * getComputedStyle during a transition returns the interpolated value -- so
+ * measuring straight after the click reads a colour that is on screen for a
+ * moment and belongs to neither rail. That is what this used to do: it passed
+ * locally on timing luck and failed on CI three runs out of three, reporting
+ * `rgba(88, 88, 88, 0.65) on rgb(167, 174, 181)`, which is no token in the file.
+ */
+const settled = async(page: Page): Promise<void> => {
+  let previous = ''
+  await expect.poll(async() => {
+    const current = JSON.stringify(await railColours(page))
+    const stable = current === previous
+    previous = current
+    return stable
+  }, { message: 'rail colours stop changing', timeout: 5000 }).toBe(true)
+}
+
 const open = async(page: Page) => {
   // The name comes from the login page and is cached; seeding it means the
   // header has something to render.
@@ -59,6 +79,7 @@ const open = async(page: Page) => {
   })
   await page.goto('/#/demo/product')
   await page.waitForSelector('.el-menu')
+  await settled(page)
 }
 
 /** Flips the rail through the settings drawer, the way a user would. */
@@ -67,6 +88,7 @@ const switchRail = async(page: Page, to: 'light' | 'dark') => {
   await expect(page.locator('.rightPanel-container')).toHaveClass(/show/)
   await page.locator(`.setting-drawer-block-checbox-item:has(img[alt="${to}"])`).click()
   await page.locator('.rightPanel-close').click()
+  await settled(page)
 }
 
 test.describe('sidebar rail', () => {


### PR DESCRIPTION
The dark palette has been in the tree for a while with no way to turn it on. This is the switch — and the first two things it found.

## The palette had no door

`styles/tokens.css` carries a complete dark palette, and `main.js` imports Element Plus's dark variable sheet. Nothing in the repository ever put the `dark` class on `<html>`. Both were maintained without ever rendering once.

Forced on by hand, the result is already good — which is the argument for shipping the switch rather than reworking the palette.

**Three values, not two.** `system` follows the operating system and keeps following it, which is what a preference nobody set should do. `light` and `dark` are a decision and stop following. The choice is remembered: one that reset on reload would be worse than none, because the page would flash the theme the user just rejected.

## The decision is made twice, deliberately

A snippet in `index.html` applies the class **before the first byte of CSS is parsed**. A module script cannot do this — those are deferred, so by the time one runs the first paint has happened, and a stored `dark` preference would show a frame of the light theme.

`src/utils/color-scheme.ts` owns it from then on. Both read the same key and the same rules, the comments in each say so, and one of the tests checks they agree rather than trusting that they will.

`colorScheme` is seeded from storage rather than from `src/settings.js`, which is why no default appears there — a default in that file could only disagree with what the snippet has already painted.

The axis is separate from `themeStyle`, which picks the sidebar surface. Both live in the drawer with labels that say which is which.

## Two things the switch found immediately

This is what "add the door first, then see what breaks" was for. Neither was guessed at.

**The drawer could not be read in the mode it turns on.** Its own styles were `rgba(0, 0, 0, .65)` text and a `#1890ff` accent, hard-coded. Fixed in the same commit, because a control panel has to work in the state it produces.

**`index.html`'s page background had drifted twice over.** It carries its own copy of the body colour, since the page needs one before the stylesheet exists — and that copy held `#f0f1f5`, the grey of the palette before last, and had no dark branch at all:

```
Expected: "rgb(10, 10, 10)"      ← what --ga-bg-body says
Received: "rgb(245, 245, 245)"   ← what index.html actually gave
```

So dark mode kept a light page underneath everything that did not cover it. That is its own commit, because the stale grey was a bug before this branch existed and can be reverted on its own.

## Verification

Five end-to-end tests: a stored dark preference applied before anything renders, a stored light one staying light, the two copies of the background agreeing, the drawer switching and the choice surviving a reload, and an unset preference following a `colorScheme: 'dark'` browser context.

Removing the dark branch from `index.html` turns two of them red with the drift printed, as above.

lint 0 errors (29 pre-existing warnings) · type-check clean · unit 220 · e2e **142** · `build:prod` ok.

## Also in here

`docs📝` corrects the palette's provenance. The comments credited "Ant Design 5"; **antd 6 has been the released major since earlier this year — 6.6.1 at the time of writing** — so a reader checking the values against current docs was looking at the wrong version of them.

The values needed no change. Every one was compared against antd 6.6.1's computed design tokens under both algorithms: four seed colours, four text opacities, both borders, three background surfaces, `colorFillTertiary`. All match. The single deviation is now stated where it is made — `colorBgLayout` is `#000000` in antd's dark algorithm, and this uses `#0a0a0a` because the documented surface ladder needs room *below* the page for the sidebar, which pure black does not leave.

## What the switch found, and what that says about the estimate

Adding the door was the point. Within minutes it turned up four pages painted light through the dark scheme, none of them guessed at:

| | |
|---|---|
| `dashboard/admin` | `background-color: #f0f2f5` on the page's **own plane**, so every card on it sat on a white sheet |
| `ChartCard` | three text colours and the accent's fallback |
| `RankList` | two text colours and the placeholder medal |
| `error-page/404` | the headline, and a hard-coded link blue |

RankList's gold/silver/bronze gradients stay literal, with a comment saying why: they encode rank, not theme.

**The audit that found them ships with them.** `tests/e2e/mocked/dark-mode-audit.spec.ts` walks eight routes in the dark scheme and fails on any box big enough to see whose background is light, or whose text does not reach 3:1 against whatever is actually behind it.

That replaces how this was being estimated. Grepping for hex literals **over-counts by more than an order of magnitude**: `src` holds around four hundred, and on these routes four were rendering wrong. Most sit behind a rule something else overrides, or belong to artwork, or are a chart's categorical palette — all fine, and all indistinguishable from a real fault in a grep.

It reports a floor, not a ceiling. Only routes the fixture can reach are visited and the list is in the file, so a page nobody adds there is a page nobody is checking. Two of these four were missed by an ad-hoc version of the same probe that capped its output per route.

## One test defect, caught by CI

The sidebar-rail test measured colours straight after clicking the switch. Element Plus transitions a menu row over 300ms and `getComputedStyle` returns the interpolated value mid-transition, so it read a colour belonging to neither rail. It passed locally on timing luck and failed on CI three runs out of three:

```
row text rgba(88, 88, 88, 0.65) on rgb(167, 174, 181)   3.17:1
```

Neither value appears in the token file, which is what gave it away — nothing was wrong with the rail, the measurement was early. It now polls until two consecutive reads agree.
