### PR TITLE
fix: stop the guard looping against getinfo when the backend is down

### DIFF
--- a/src/permission.js
+++ b/src/permission.js
@@ -49,8 +49,19 @@ router.beforeEach(async(to, from, next) => {
           // set the replace: true, so the navigation will not leave a history record
           next({ ...to, replace: true })
         } catch(error) {
-          // remove token and go to login page to re-login
-          // await store.dispatch('user/resetToken')
+          // Drop the token before redirecting, or this loops.
+          //
+          // The guard reads a token as "signed in", so leaving it in place after
+          // the lookup failed sends /login straight back to / (see the branch
+          // above), which arrives with no roles, which calls getInfo again. On a
+          // backend returning 502 that is an unbounded stream of requests at
+          // whatever speed the server can refuse them -- and unlike a 401, a 502
+          // carries nothing that would end the session on its own.
+          //
+          // The line was here as a commented-out Vuex dispatch, left behind when
+          // the store was ported.
+          useUserStore().resetToken()
+
           // Only report what nobody has reported yet. An HTTP failure here has
           // already produced a toast from the response interceptor; the one
           // failure this catch knows about on its own is a client-side throw,

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -102,8 +102,23 @@ export const useUserStore = defineStore('user', {
       storage.clear()
     },
 
+    /**
+     * Ends the session locally, without telling the server.
+     *
+     * Used where the session cannot be continued but there is nobody to log out
+     * from -- the router guard calls it when the profile lookup fails, which is
+     * exactly when a request to /logout would fail too.
+     *
+     * It clears the profile as well as the token. A caller reaching this has a
+     * session it could not finish building, and leaving half of one behind means
+     * the next guard pass reads `roles.length > 0` and lets the user through to
+     * a page with no permissions loaded.
+     */
     resetToken() {
       this.token = ''
+      this.roles = []
+      this.permisaction = []
+      this.name = ''
       removeToken()
     }
   }

--- a/tests/e2e/mocked/session-recovery.spec.ts
+++ b/tests/e2e/mocked/session-recovery.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test'
+import { authenticate, installApiMocks } from './fixtures'
+
+/**
+ * What the application does when the backend is down but the session is not.
+ *
+ * A token in the cookie says "signed in"; the roles that decide which routes
+ * exist come from GET /api/v1/getinfo. When that call fails, the guard has a
+ * token it cannot use, and every path out of that state has to end somewhere.
+ * The one it must not take is back into itself.
+ */
+test.describe('a failing session lookup', () => {
+  test('stops asking instead of hammering the endpoint', async({ page, context }) => {
+    await authenticate(context)
+    await installApiMocks(page)
+
+    // Counted here rather than through the fixture: this route overrides the
+    // fixture's, so its counter stops moving.
+    let attempts = 0
+    // 502 is what a restarting or crash-looping backend returns through nginx,
+    // and it is the case that used to loop: unlike a 401, nothing in the
+    // response tells the client its session is finished.
+    await page.route(/\/api\/v1\/getinfo/, route => {
+      attempts++
+      return route.fulfill({
+        status: 502,
+        contentType: 'text/html',
+        body: '<html><body><h1>502 Bad Gateway</h1></body></html>'
+      })
+    })
+
+    await page.goto('/#/admin/sys-user')
+    await page.waitForURL(/#\/login/, { timeout: 15_000 })
+    await page.waitForSelector('form')
+
+    // Settle, then measure. A loop shows up as a count that keeps climbing;
+    // the fix shows up as one that does not. Before the fix this reached the
+    // hundreds and the page never arrived at /login at all.
+    const afterArrival = attempts
+    await page.waitForTimeout(3000)
+
+    expect(attempts, 'getinfo is not retried in a loop').toBe(afterArrival)
+    // One attempt is expected. A handful would mean a slower loop rather than
+    // no loop, which is why this is not a "fewer than fifty" check.
+    expect(afterArrival).toBeLessThanOrEqual(2)
+  })
+
+  test('leaves the user on the login page, not bouncing off it', async({ page, context }) => {
+    await authenticate(context)
+    await installApiMocks(page)
+
+    await page.route(/\/api\/v1\/getinfo/, route => route.fulfill({
+      status: 502, contentType: 'text/html', body: '502'
+    }))
+
+    await page.goto('/#/admin/sys-user')
+    await page.waitForURL(/#\/login/, { timeout: 15_000 })
+    await page.waitForSelector('form')
+
+    // The stale token has to go. While it is there the guard reads the session
+    // as live, sends /login back to /, and the whole thing starts again.
+    await page.waitForTimeout(2000)
+    expect(page.url()).toContain('#/login')
+
+    const token = (await context.cookies()).find(c => c.name === 'Admin-Token')
+    expect(token?.value ?? '', 'the unusable token is cleared').toBe('')
+  })
+
+  test('leaves no half-built session behind', async({ page, context }) => {
+    await authenticate(context)
+    await installApiMocks(page)
+
+    await page.route(/\/api\/v1\/getinfo/, route => route.fulfill({
+      status: 502, contentType: 'text/html', body: '502'
+    }))
+
+    await page.goto('/#/admin/sys-user')
+    await page.waitForURL(/#\/login/, { timeout: 15_000 })
+    await page.waitForSelector('form')
+
+    // The guard treats `roles.length > 0` as "this session is ready". A failure
+    // that cleared the token but kept the profile would let the next pass
+    // through to a page with no permissions loaded, so the reset clears both.
+    // Read through the DOM: the sidebar is built from the roles, so an empty one
+    // is the observable form of "no profile left over".
+    expect(await page.locator('.el-menu-item').count(), 'no menu built from stale roles').toBe(0)
+  })
+})


### PR DESCRIPTION
Reported from the live demo: with the backend returning 502, the browser fired `/api/v1/getinfo` continuously — as fast as the server could refuse them, until the tab was closed.

## The loop

The router guard reads a token as "signed in". When `getInfo` failed it redirected to `/login` but **left the token in place**:

```
getInfo() 502 → catch → next('/login')
  → guard runs: token present, path is /login → next({ path: '/' })
  → guard runs: token present, no roles       → getInfo() → 502
  → and round again
```

Measured before the fix, with getinfo stubbed to 502:

```
finalHash:     #/admin/sys-user    ← never reached /login at all
tokenStillSet: yes                 ← the fuel
```

## The missing line was already in the file

```js
// remove token and go to login page to re-login
// await store.dispatch('user/resetToken')
```

Commented out when the store moved from Vuex to Pinia, and never replaced with its Pinia equivalent. The error path cleared the *navigation* but not the *credential*.

Restoring it ends the loop: a guard pass with no token takes the signed-out branch and stays on `/login`.

**401 was never affected** — the response interceptor calls `promptRelogin()`, which clears the token itself. A 502 arrives from nginx with nothing in the body that says the session is over, so the client has to be the one to decide. That is why this only shows up when the backend is down rather than when a session expires.

## A second, separate defect

`resetToken()` cleared the token and left `roles`, `permisaction` and `name` behind. The guard's readiness check is `roles.length > 0`, so a reset that keeps them can admit the next pass to a page whose permissions were never loaded.

The 502 path does not reach that state — the profile is still empty when `getInfo` fails. A failure one step later does: `generateRoutes()` throwing lands in the same `catch` with roles already populated.

Its own commit, since it is a different defect from the one that caused the loop and can be reverted on its own.

## Verification

Three end-to-end tests, driving a stubbed 502:

- `getinfo` is not retried in a loop — the count after arrival stays put for three seconds
- the user lands on `/login` **and the cookie is cleared**
- no half-built session is left behind — no menu is built from stale roles

Removing the restored line turns **all three red**, with the first one failing exactly as the bug behaves: `waitForURL(/#\/login/)` times out because the page never gets there.

lint 0 errors (29 pre-existing warnings) · type-check clean · unit 220 · e2e **146**.
