### PR TITLE
fix: stop the tab strip clipping the tabs' top border

### DIFF
--- a/src/layout/components/TagsView/index.vue
+++ b/src/layout/components/TagsView/index.vue
@@ -283,8 +283,16 @@ String.prototype.colorRgb = function() {
   box-sizing: border-box;
   display: flex;
   align-items: flex-end;
-  // el-tabs__header 固定 40px，而容器含 1px 下边框后内容区仅 39px，
-  // 底部对齐会使其向上溢出 1px 并压在 navbar 边框上，形成一条贯穿的横线
+  // A tab is 32px plus a 1px border top and bottom, so it needs 34px of room.
+  // The strip is 40px including its own bottom border, which leaves 39px --
+  // enough, provided nothing above the tabs eats into it. It used to: the row
+  // was sized by `height: 100%` against a flex line that had already been
+  // shortened, so the tabs sat one pixel proud of it and this overflow rule
+  // cut their top border off. Tabs are cards; without the top edge they read
+  // as open-topped boxes.
+  //
+  // The clip stays -- a tab must not climb into the navbar's border either --
+  // but the row below now reserves the height rather than relying on it.
   overflow: hidden;
 
   // el-tabs 整体铺满容器
@@ -297,9 +305,11 @@ String.prototype.colorRgb = function() {
   .el-tabs__header {
     margin: 0;
     border-bottom: none !important;
-    // 默认固定 40px，会超出容器内容区（40px 减去 1px 下边框）并向上压住
-    // navbar 的边框；改为自适应高度并让页签底部对齐
-    height: 100%;
+    // Sized to the tab it holds -- 32px of content plus its two 1px borders --
+    // rather than to the strip. `height: 100%` measured against a flex line
+    // that had already lost a pixel to the strip's own border, so the row came
+    // out at 31px and the 34px tab overflowed it upward into the clip.
+    height: 34px;
     display: flex;
     align-items: flex-end;
   }

--- a/tests/e2e/mocked/tags-view-chrome.spec.ts
+++ b/tests/e2e/mocked/tags-view-chrome.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test'
+import { authenticate, installApiMocks } from './fixtures'
+
+/**
+ * The tab strip's own geometry.
+ *
+ * A tab is drawn as a card with a border on three sides, so the top edge is
+ * what makes it read as a tab rather than as a label. It sits in a 40px strip
+ * that clips its overflow, which is a combination that hides a defect rather
+ * than showing one: a tab one pixel too tall for its row loses that edge
+ * silently, and every other test still passes because the tab is present,
+ * clickable and correctly labelled.
+ */
+test.describe('the tab strip', () => {
+  test.beforeEach(async({ page, context }) => {
+    await authenticate(context)
+    await installApiMocks(page)
+    await page.setViewportSize({ width: 1280, height: 720 })
+    await page.goto('/#/admin/sys-menu')
+    await page.waitForSelector('.el-tabs__item')
+    // Element Plus positions the strip after a tick; measuring before it
+    // settles reads the pre-layout numbers.
+    await page.waitForTimeout(800)
+  })
+
+  test('a tab keeps its top edge inside the row that clips it', async({ page }) => {
+    // Measured against the row the tabs are laid out in, not the strip's border
+    // box. The strip is 40px tall and clips overflow, but the tabs sit in
+    // .el-tabs__header inside it -- so a tab can be within the strip's outer
+    // bounds and still have its top cut off. Comparing against the strip is
+    // what let this pass while the border was missing on screen.
+    const row = await page.locator('.el-tabs__header').boundingBox()
+    const tab = await page.locator('.el-tabs__item').first().boundingBox()
+    expect(row && tab).toBeTruthy()
+
+    // Shipped as tab top 57 against a row starting at 58: one pixel out, which
+    // is exactly the border, so the tab read as an open-topped box.
+    expect(tab!.y, `tab top ${tab!.y} vs row top ${row!.y}`).toBeGreaterThanOrEqual(row!.y)
+  })
+
+  test('the tab and the bar below it stay apart', async({ page }) => {
+    const navbar = await page.locator('.navbar').boundingBox()
+    const tab = await page.locator('.el-tabs__item').first().boundingBox()
+
+    // The other half of the same squeeze: a tab tall enough to clear the strip
+    // would instead climb into the navbar's bottom border and draw a line
+    // through it. Neither end may overlap.
+    expect(tab!.y, 'the tab starts below the navbar').toBeGreaterThanOrEqual(navbar!.y + navbar!.height)
+  })
+
+  test('every tab has a visible top border', async({ page }) => {
+    const borders = await page.locator('.el-tabs__item').evaluateAll(nodes =>
+      nodes.map(node => getComputedStyle(node as HTMLElement).borderTopWidth)
+    )
+
+    expect(borders.length).toBeGreaterThan(0)
+    // Declared and rendered are different things -- this only proves the rule
+    // applies. The geometry checks above are what prove it is on screen.
+    expect(borders.every(width => parseFloat(width) > 0), `border widths: ${borders}`).toBe(true)
+  })
+})


### PR DESCRIPTION
A tab is a card with a border on three sides, and the top edge was cut off — the tab read as an open-topped box.

## The arithmetic

A tab is 32px of content plus 1px of border top and bottom: **34px**. Its row was sized `height: 100%` against a flex line the strip's own 1px bottom border had already shortened, so the row came out **31px** and the tab sat one pixel proud of it — straight into the strip's `overflow: hidden`.

```
tab top 57  vs  row top 58
```

The row now reserves 34px rather than inheriting what is left. The clip stays: at the other end a tab must not climb into the navbar's border, and the second test covers that.

## Not the blue line

The screenshot that started this shows a blue line right above the tabs. It is a deliberate 2px gradient on `.navbar::after`, unrelated — but it sits directly above the tabs' top border, which is why a missing border reads as something covering it.

## The first version of the test passed against the bug

It compared the tab against the strip's **border box** (top 50) while the clipping happens at the **content box** (top 58), so 57 cleared it. Comparing against the row the tabs actually live in is what turned it red. Worth knowing if these numbers are ever revisited.

lint 0 errors · type-check clean · unit 220 · e2e **149**.