### PR TITLE
refactor🎨: let useForm take validation rules that follow the language

### DIFF
--- a/src/composables/useForm.ts
+++ b/src/composables/useForm.ts
@@ -1,5 +1,5 @@
 import { ref, reactive, computed, nextTick } from 'vue'
-import type { Ref } from 'vue'
+import type { MaybeRef, Ref } from 'vue'
 import { asReportedError } from '@/utils/request'
 import type { ReportedError } from '@/utils/request'
 import type { FormInstance, FormRules } from 'element-plus'
@@ -31,8 +31,16 @@ export interface UseFormOptions<TModel extends object, TId = unknown> {
   /** Initial model, as a factory so each open starts from a fresh object. */
   defaultModel: () => TModel
 
-  /** Element Plus validation rules. */
-  rules?: FormRules
+  /**
+   * Element Plus validation rules.
+   *
+   * Accepts a computed as well as a plain object, and translated pages need
+   * one: a plain `const rules = { ... }` is evaluated once, so a message built
+   * from t() keeps whichever language was current when the module loaded. The
+   * page still binds :rules="form.rules" -- the ref is unwrapped on the way
+   * out.
+   */
+  rules?: MaybeRef<FormRules>
 
   /**
    * Primary-key field. Its presence on the model decides whether submitting
@@ -95,7 +103,8 @@ export interface UseFormReturn<TModel extends object, TId = unknown> {
   model: TModel
   /**
    * The rules passed in, handed back so the page can bind :rules="form.rules"
-   * rather than keeping its own copy.
+   * rather than keeping its own copy. Unwrapped, so a computed passed in
+   * arrives here as a plain object.
    */
   rules: FormRules | undefined
   /** True while a submit is in flight. Bind to the confirm button's `loading`. */

--- a/tests/unit/composables/useForm.spec.ts
+++ b/tests/unit/composables/useForm.spec.ts
@@ -1,4 +1,5 @@
-import { nextTick } from 'vue'
+import { computed, nextTick, ref } from 'vue'
+import type { FormRules } from 'element-plus'
 import { useForm } from '@/composables/useForm'
 import type { ApiResponse } from '@/types/api'
 import { deferred } from '../support/async'
@@ -145,6 +146,47 @@ describe('useForm', () => {
 
       await form.openEdit({ userId: 1 })
       expect(form.title).toBe('修改用户')
+    })
+  })
+
+  describe('validation rules', () => {
+    it('follows a computed, so a translated page can rebuild its messages', () => {
+      // Pages declare `const rules = { ... }` at module scope, which is
+      // evaluated once. Once the messages come from t(), that freezes them in
+      // whichever language was current when the module loaded -- and the error
+      // a user is looking at right now would keep the old wording after they
+      // switch. Passing a computed is the fix, and this is what makes it
+      // possible: reactive() unwraps it on the way out, so the page still binds
+      // :rules="form.rules" and nothing else changes.
+      const chinese = ref(true)
+      const rules = computed<FormRules>(() => ({
+        username: [{ required: true, message: chinese.value ? '用户名称不能为空' : 'Username is required' }]
+      }))
+
+      const form = useForm<User, number>({
+        defaultModel: defaultUser,
+        rules,
+        submit: () => Promise.resolve()
+      })
+
+      const message = () => (form.rules?.username as Array<{ message: string }>)[0].message
+      expect(message()).toBe('用户名称不能为空')
+
+      chinese.value = false
+      expect(message()).toBe('Username is required')
+    })
+
+    it('still takes a plain object', () => {
+      // The other fifteen pages have not been migrated yet, and must keep
+      // working untouched.
+      const form = useForm<User, number>({
+        defaultModel: defaultUser,
+        rules: { username: [{ required: true, message: '用户名称不能为空' }] },
+        submit: () => Promise.resolve()
+      })
+
+      expect((form.rules?.username as Array<{ message: string }>)[0].message)
+        .toBe('用户名称不能为空')
     })
   })
 


### PR DESCRIPTION
Second prerequisite for translating the business pages. One-line type change plus the test that proves it.

## The problem it unblocks

Fifteen pages across thirteen files declare their validation rules as a module-scope constant:

```ts
const rules: FormRules = {
  username: [{ required: true, message: '用户名称不能为空', trigger: 'blur' }]
}
```

Module scope is evaluated **once**. That is fine while the message is a literal, and wrong as soon as it comes from `t()` — the rules freeze in whichever language was current when the module loaded, so an error message the user is looking at right now keeps its old wording after they switch.

## Why it cannot be caught later

The existing e2e only triggers validation with the interface in Chinese. Every message is Chinese from start to finish, so the assertions pass whether or not the rules are reactive. The login page hit the same shape in the previous batch (rules built in `data()`, same once-only evaluation) and it was found by hand, not by a test.

## The change

`rules?: FormRules` → `rules?: MaybeRef<FormRules>`. `reactive()` already unwraps it on the way out, so pages keep binding `:rules="form.rules"` and nothing else moves. A plain object still works — the pages migrate in batches, and the other fourteen must keep running untouched.

Both cases are covered: a computed whose message changes when a ref flips, and a plain object. Reverting the type makes `vue-tsc` fail with TS2322, so the test is anchored to the change rather than passing either way.