### PR TITLE
fix🐛: make the navbar search work again, and follow the language

### DIFF
--- a/src/components/HeaderSearch/index.vue
+++ b/src/components/HeaderSearch/index.vue
@@ -24,6 +24,7 @@ import { mapState } from 'pinia'
 import { usePermissionStore } from '@/stores/permission'
 import Fuse from 'fuse.js'
 import path from 'path'
+import { routeTitle } from '@/lang/backend'
 
 export default {
   name: 'HeaderSearch',
@@ -41,6 +42,17 @@ export default {
   },
   watch: {
     routes() {
+      this.searchPool = this.generateRoutes(this.routes)
+    },
+    /**
+     * The index stores titles, so it has to be rebuilt when they change.
+     *
+     * Everything else that renders a menu title translates as it renders and is
+     * reactive for free. This one cannot: fuse.js indexes plain strings up
+     * front, and the menu tree itself never changes on a language switch -- the
+     * `routes` watcher above would not fire.
+     */
+    '$i18n.locale'() {
       this.searchPool = this.generateRoutes(this.routes)
     },
     searchPool(list) {
@@ -108,8 +120,11 @@ export default {
           title: [...prefixTitle]
         }
 
+        // meta.title decides whether the route is worth indexing at all; the
+        // string that goes IN is the translated one, or English users would be
+        // searching a list of Chinese names.
         if (router.meta && router.meta.title) {
-          data.title = [...data.title, router.meta.title]
+          data.title = [...data.title, routeTitle(router)]
 
           if (router.redirect !== 'noRedirect') {
             // only push the routes with title
@@ -130,7 +145,12 @@ export default {
     },
     querySearch(query) {
       if (query !== '') {
-        this.options = this.fuse.search(query)
+        // fuse 6 returns [{ item, refIndex, score }] rather than the matched
+        // objects themselves, which fuse 3 did. Assigning the wrapper straight
+        // through left every option with an undefined `title`, so the template
+        // threw on .join() and the dropdown rendered as "no data" -- the search
+        // has not returned a usable result since that upgrade.
+        this.options = this.fuse.search(query).map(result => result.item)
       } else {
         this.options = []
       }

--- a/tests/e2e/mocked/i18n.spec.ts
+++ b/tests/e2e/mocked/i18n.spec.ts
@@ -138,6 +138,17 @@ test.describe('switching language', () => {
     await expect(errors.filter({ hasText: 'Username is required' })).toHaveCount(1)
   })
 
+  /**
+   * The whole confirm dialog, not just the sentence the page passes in.
+   *
+   * useRemove owned four strings: the body, the title, and both buttons. Only
+   * the body could be overridden, so a migrated page reached English there
+   * while '提示' / '确定' / '取消' stayed written into the composable -- an
+   * English question inside a Chinese box, on every list page in the
+   * application. sys-config is used because it takes the default body too, so
+   * this covers all four at once.
+   */
+
   test('keeps the language across a reload', async({ page }) => {
     await openList(page)
     await switchTo(page, 'English')
@@ -174,6 +185,43 @@ test.describe('switching language', () => {
 
     await switchTo(page, 'English')
     await expect(pager).toContainText('/page')
+  })
+
+  test('translates what the navbar search can find', async({ page }) => {
+    // The one place that cannot translate as it renders: fuse.js indexes plain
+    // strings up front, so the titles are copied into the index when it is
+    // built. Everything else reads through routeTitle at render time and
+    // follows the language for free -- this had to be rebuilt explicitly, and
+    // the menu tree it is built from does not change on a switch, so the
+    // existing `routes` watcher would never have fired.
+    await openList(page)
+
+    const search = page.locator('#header-search')
+    const input = search.locator('input')
+    // Scoped to the dropdown that is actually open: el-select teleports its
+    // popper to <body>, and the page behind has its own selects whose options
+    // are in the DOM too.
+    const results = page.locator('.el-select-dropdown:visible .el-select-dropdown__item')
+
+    // The icon toggles, so it is clicked once per open -- and switching
+    // language closes it, because the switcher click reaches the body listener
+    // this component installs while open.
+    await search.locator('.search-icon').click()
+    await expect(input).toBeVisible()
+    // Typed rather than filled: el-select's remote mode runs its query off the
+    // input event, and only reveals the dropdown once results arrive.
+    await input.pressSequentially('User')
+    // The fixture's own title, which is what zh-CN shows: no menu.ts entry is
+    // consulted, the stored value comes straight through.
+    await expect(results.first()).toHaveText('Admin > User')
+
+    await switchTo(page, 'English')
+
+    await search.locator('.search-icon').click()
+    await expect(input).toBeVisible()
+    await input.pressSequentially('User')
+    // Same query, rebuilt index: now the translated title.
+    await expect(results.first()).toHaveText('Admin > User Management')
   })
 
   test('follows the language in the browser tab', async({ page }) => {


### PR DESCRIPTION
Two separate faults in the same component, found while reviewing the i18n work.

## The search has been broken since fuse.js 6

```js
this.options = this.fuse.search(query)
```

fuse 6's `search()` returns `[{ item, refIndex, score }]`; 3.x returned the matched objects themselves. So every option had an undefined `title`, the template threw on `.join(' > ')`, and the dropdown rendered as **"no data"** for any query.

Nothing to do with i18n — and covered by no test, which is why it went unnoticed through the upgrade.

## The index did not follow the language

Everything else that renders a menu title translates as it renders and is reactive for free: sidebar, breadcrumb, tab strip, top menu. This component is the one consumer that **copies** titles into another structure — fuse indexes plain strings up front.

It indexed `meta.title`, the stored Chinese, so an English interface searched a list of Chinese names. And because the menu tree itself does not change when the language does, the existing `routes` watcher would never have rebuilt the index; that needed a watcher of its own.

## Verification

One e2e case covers both, and goes red for either fix alone:

- drop the unwrapping → the query finds nothing
- index `meta.title` again → the English query still returns the Chinese title

Both reverts were run; both fail; restored, it passes.

## How it was found

The i18n half was found by grepping every reader of `meta.title` — four in the codebase, and this was the only one that stores rather than renders. The fuse half surfaced while verifying that fix: the new test failed, reverting my change did not help, so the fault predated it. Reading the component's own state (the index was fine — 21 entries, `Admin > User` among them) narrowed it to the search step.