### PR TITLE
refactor🎨: translate the dialogs the shared composables own

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,29 @@ el-form 用 **`:ref="form.bindFormRef"`** 绑定（注意有冒号，是表达�
 
 `useRemove` 是例外，返回的是 ref，因为它的用法是解构（`const { remove } = ...`）；
 解构 reactive 对象会丢失响应性，解构出来的 ref 反而能在模板里自动解包。
+`useExport` / `useDict` 同理。**判据只有一条：调用方是属性访问就 `reactive()`，
+是解构就返回裸 ref。** 两者搞反不会报错——裸对象里的 computed 被属性访问取出来时
+不解包，模板拿到的是 `ComputedRef`，组件只在控制台刷
+`Invalid prop: type check failed`，功能照常。`useTreePicker` 曾经就是这样，
+`sys-dept` 一轮 e2e 刷 18 条、`sys-menu` 22 条，页面看不出任何异常。
+
+### composable 的内置文案跟随语言
+
+`useRemove` 的确认框（标题/正文/两个按钮）、`useForm` 的对话框标题与提交成功提示，
+默认值都从语言包取，**不用页面再传**。composable 没有组件实例，走
+`import { i18n } from '@/lang'` + `i18n.global.t(...)`，且**取值必须发生在每次用到的时候**——
+写在函数体、computed 或回调里都行，直接写成 `useXxx({ title: t('...') })` 这种在
+setup 阶段就求值的形式不行，那等于把整个页面钉死在打开时的语言。
+
+页面要覆盖默认值时，凡是"取一次就固定"的选项都收 `MaybeRef`，传 `computed(() => t(...))`：
+
+| 选项 | 类型 |
+|---|---|
+| `useForm` 的 `rules` | `MaybeRef<FormRules>` |
+| `useForm` 的 `title.create` / `title.edit` | `MaybeRef<string>` |
+| `useTreePicker` 的 `rootLabel` | `MaybeRef<string>` |
+
+`useRemove` 的 `confirmText` 不需要，它本来就是 `(count) => string`，每次开框都重新调用。
 
 字典用 `useDict`（模块级缓存，同一字典全站只取一次）：
 

--- a/src/composables/useForm.ts
+++ b/src/composables/useForm.ts
@@ -1,9 +1,10 @@
-import { ref, reactive, computed, nextTick } from 'vue'
+import { ref, reactive, computed, nextTick, unref } from 'vue'
 import type { MaybeRef, Ref } from 'vue'
 import { asReportedError } from '@/utils/request'
 import type { ReportedError } from '@/utils/request'
 import type { FormInstance, FormRules } from 'element-plus'
 import { msgSuccess } from '@/utils/message'
+import { i18n } from '@/lang'
 import type { ApiResponse } from '@/types/api'
 
 /**
@@ -64,8 +65,17 @@ export interface UseFormOptions<TModel extends object, TId = unknown> {
    */
   submit?: SubmitFn<TModel>
 
-  /** Dialog titles. */
-  title?: { create?: string, edit?: string }
+  /**
+   * Dialog titles. Default to 新增 / 修改 in whichever language is current.
+   *
+   * Each accepts a computed as well as a plain string, for the same reason
+   * `rules` does: a page that passes `t('admin.sysDept.addTitle')` directly
+   * resolves it once, when the page is set up, and the dialog then keeps that
+   * language for as long as the page stays alive. Pass
+   * `computed(() => t(...))` instead -- the title below unwraps it on every
+   * read.
+   */
+  title?: { create?: MaybeRef<string>, edit?: MaybeRef<string> }
 
   /** Toast shown after a successful submit. Pass null to stay silent. */
   successMessage?: string | ((model: TModel, isEdit: boolean) => string) | null
@@ -176,8 +186,14 @@ export function useForm<TModel extends object, TId = unknown>(
     return id !== undefined && id !== null && id !== ''
   })
 
+  // Inside the computed, so both halves are re-read on every render: the
+  // defaults follow the language for free, and an unref'd title does too.
+  // This composable has no component instance, so t() comes off the i18n
+  // instance rather than useI18n() -- the same route utils/request.ts takes.
   const title = computed(() =>
-    isEdit.value ? (titles.edit ?? '修改') : (titles.create ?? '新增')
+    isEdit.value
+      ? (unref(titles.edit) ?? i18n.global.t('common.edit'))
+      : (unref(titles.create) ?? i18n.global.t('common.add'))
   )
 
   const reset = () => {
@@ -271,7 +287,9 @@ export function useForm<TModel extends object, TId = unknown>(
       if (successMessage !== null) {
         const text = typeof successMessage === 'function'
           ? successMessage(model.value, editing)
-          : successMessage ?? (editing ? '修改成功' : '新增成功')
+          : successMessage ?? (editing
+            ? i18n.global.t('composables.form.editSuccess')
+            : i18n.global.t('composables.form.addSuccess'))
         msgSuccess(text)
       }
       visible.value = false

--- a/src/composables/useRemove.ts
+++ b/src/composables/useRemove.ts
@@ -4,6 +4,7 @@ import { asReportedError } from '@/utils/request'
 import type { ReportedError } from '@/utils/request'
 import { ElMessageBox } from 'element-plus'
 import { msgSuccess } from '@/utils/message'
+import { i18n } from '@/lang'
 import type { Id } from '@/types/api'
 
 /**
@@ -35,7 +36,13 @@ export interface UseRemoveOptions {
   /** Run after a successful delete -- typically the list's `getList`. */
   onSuccess?: (ids: Id[]) => void | Promise<void>
 
-  /** Confirmation body. Defaults to a count. */
+  /**
+   * Confirmation body. Defaults to a count.
+   *
+   * A function rather than a string, which is also what makes the default
+   * follow the language: it is called when the dialog opens, so the t() inside
+   * it is resolved then rather than when the page was set up.
+   */
   confirmText?: (count: number) => string
 
   /** Toast after a successful delete. Pass null to stay silent. */
@@ -71,7 +78,8 @@ export function useRemove(options: UseRemoveOptions): UseRemoveReturn {
   const {
     api,
     onSuccess,
-    confirmText = (count: number) => `确认删除选中的 ${count} 条数据？`,
+    confirmText = (count: number) =>
+      i18n.global.t('composables.remove.confirm', { count }, count),
     successMessage,
     onError
   } = options
@@ -98,10 +106,14 @@ export function useRemove(options: UseRemoveOptions): UseRemoveReturn {
     pending = true
     try {
       try {
-        await ElMessageBox.confirm(confirmText(ids.length), '提示', {
+        // Read here rather than once at setup: this composable has no
+        // component instance, so it cannot use useI18n(), and a title resolved
+        // when the page loaded would keep that language for the rest of the
+        // session. Same reason and same shape as utils/request.ts.
+        await ElMessageBox.confirm(confirmText(ids.length), i18n.global.t('common.notice'), {
           type: 'warning',
-          confirmButtonText: '确定',
-          cancelButtonText: '取消'
+          confirmButtonText: i18n.global.t('common.confirm'),
+          cancelButtonText: i18n.global.t('common.cancel')
         })
       } catch {
         // Dismissing the dialog is a decision, not a failure
@@ -110,7 +122,9 @@ export function useRemove(options: UseRemoveOptions): UseRemoveReturn {
 
       removing.value = true
       await api(ids)
-      if (successMessage !== null) msgSuccess(successMessage ?? '删除成功')
+      if (successMessage !== null) {
+        msgSuccess(successMessage ?? i18n.global.t('composables.remove.success'))
+      }
       await onSuccess?.(ids)
       return true
     } catch(error) {

--- a/src/composables/useTreePicker.ts
+++ b/src/composables/useTreePicker.ts
@@ -1,5 +1,5 @@
-import { ref, computed } from 'vue'
-import type { ComputedRef } from 'vue'
+import { ref, reactive, computed, unref } from 'vue'
+import type { MaybeRef } from 'vue'
 import type { ApiResponse } from '@/types/api'
 
 /**
@@ -23,7 +23,7 @@ import type { ApiResponse } from '@/types/api'
  *     api: () => listMenu({}),
  *     idKey: 'menuId',
  *     labelKey: 'title',
- *     rootLabel: '主类目'
+ *     rootLabel: computed(() => t('admin.sysMenu.rootCategory'))
  *   })
  *
  *   // opening a dialog
@@ -42,15 +42,34 @@ export interface UseTreePickerOptions<TRow> {
   idKey: string
   /** Field el-tree-select shows as the label. */
   labelKey: string
-  /** Label of the synthetic root, e.g. '主类目'. */
-  rootLabel: string
+  /**
+   * Label of the synthetic root, e.g. 主类目.
+   *
+   * Accepts a computed as well as a plain string, and a translated page needs
+   * one: a plain `t(...)` is resolved once, when the page is set up, so the one
+   * node in the picker that is not a database record would keep whichever
+   * language the page was opened in while every branch under it changed.
+   */
+  rootLabel: MaybeRef<string>
   /** Value the synthetic root carries. Backends use 0 for "no parent". */
   rootId?: number
 }
 
+/**
+ * Plain values, not Refs -- the object is wrapped in reactive() before it is
+ * returned, the way useTable and useForm are.
+ *
+ * The rule is what the call site does with it. This one is reached by property
+ * access (`parent.options`, `parent.ensure()`), and property access on a plain
+ * object hands the template the ComputedRef itself: el-tree-select then got an
+ * object where its `data` prop declares an array and logged `Invalid prop: type
+ * check failed for prop "data"` on every render. useRemove, useExport and
+ * useDict return bare objects holding refs on purpose -- those are destructured,
+ * and destructuring a reactive object would snapshot the values instead.
+ */
 export interface UseTreePickerReturn<TRow> {
   /** Bind to el-tree-select's `data`. The synthetic root wraps the tree. */
-  options: ComputedRef<TRow[]>
+  options: TRow[]
   /** Loads the tree unless it is already current. Safe to call on every open. */
   ensure: () => Promise<void>
   /** Marks the tree stale, so the next `ensure()` refetches it. */
@@ -89,8 +108,12 @@ export function useTreePicker<TRow extends object>(
   const invalidate = () => { current = false }
 
   const pickerOptions = computed<TRow[]>(() => [
-    { [idKey]: rootId, [labelKey]: rootLabel, children: tree.value } as unknown as TRow
+    { [idKey]: rootId, [labelKey]: unref(rootLabel), children: tree.value } as unknown as TRow
   ])
 
-  return { options: pickerOptions, ensure, invalidate }
+  return reactive({
+    options: pickerOptions,
+    ensure,
+    invalidate
+  }) as UseTreePickerReturn<TRow>
 }

--- a/src/lang/en-US/composables.ts
+++ b/src/lang/en-US/composables.ts
@@ -1,0 +1,18 @@
+export default {
+  remove: {
+    // Pluralised, which Chinese does not need: 条数据 covers any count, while
+    // 'the 1 selected records' does not. Same shape as admin.sysUser.
+    // removeConfirm -- the count is passed as the plural choice as well as a
+    // named value, and a message with no `|` is returned whole.
+    confirm: 'Delete the selected record? | Delete the {count} selected records?',
+    success: 'Deleted successfully'
+  },
+
+  form: {
+    addSuccess: 'Added successfully',
+    // 'Saved', not 'Edited': the toast reports that the change reached the
+    // server, and 'Edited successfully' describes the reader's own action back
+    // at them. 修改 is still Edit everywhere it labels the action itself.
+    editSuccess: 'Saved successfully'
+  }
+}

--- a/src/lang/en-US/index.ts
+++ b/src/lang/en-US/index.ts
@@ -5,6 +5,7 @@ import components from './components'
 import login from './login'
 import dashboard from './dashboard'
 import admin from './admin'
+import composables from './composables'
 import menu from './menu'
 import dict from './dict'
 
@@ -14,4 +15,4 @@ import dict from './dict'
  * Unlike zh-CN this does carry menu and dict: those are the translations of
  * text the backend only ever sends in Chinese.
  */
-export default { common, layout, route, components, login, dashboard, admin, menu, dict }
+export default { common, layout, route, components, login, dashboard, admin, composables, menu, dict }

--- a/src/lang/zh-CN/composables.ts
+++ b/src/lang/zh-CN/composables.ts
@@ -1,0 +1,29 @@
+/**
+ * The text the composables put on screen themselves.
+ *
+ * These are defaults, not page copy: useRemove and useForm ship a sentence for
+ * pages that do not pass their own, and until now those sentences were Chinese
+ * literals inside the composable -- so an English reader deleting a row met an
+ * English question inside a Chinese dialog with Chinese buttons. Every list page
+ * goes through them, which is why they are here rather than in one page's file.
+ *
+ * The words the dialogs share with the toolbar -- 提示 / 确定 / 取消 / 新增 /
+ * 修改 -- stay in common.ts and are read from there.
+ *
+ * Every Chinese value must be byte-for-byte what the interface renders today --
+ * PRD R5.
+ */
+export default {
+  remove: {
+    // The count is interpolated by name so the sentence can put it where the
+    // language needs it; the template literal it replaces read
+    // `确认删除选中的 ${count} 条数据？`.
+    confirm: '确认删除选中的 {count} 条数据？',
+    success: '删除成功'
+  },
+
+  form: {
+    addSuccess: '新增成功',
+    editSuccess: '修改成功'
+  }
+}

--- a/src/lang/zh-CN/index.ts
+++ b/src/lang/zh-CN/index.ts
@@ -5,6 +5,7 @@ import components from './components'
 import login from './login'
 import dashboard from './dashboard'
 import admin from './admin'
+import composables from './composables'
 
 /**
  * Chinese, the default and the fallback.
@@ -15,4 +16,4 @@ import admin from './admin'
  * drift the first time someone renamed a menu. Chinese always falls through to
  * the database value; see lang/backend.ts.
  */
-export default { common, layout, route, components, login, dashboard, admin }
+export default { common, layout, route, components, login, dashboard, admin, composables }

--- a/src/views/admin/sys-config/index.vue
+++ b/src/views/admin/sys-config/index.vue
@@ -112,7 +112,7 @@
 
     <el-dialog
       v-model="form.visible"
-      :title="form.isEdit ? $t('admin.sysConfig.editTitle') : $t('admin.sysConfig.addTitle')"
+      :title="form.title"
       width="500px"
       :close-on-click-modal="false"
       @closed="form.reset"
@@ -238,8 +238,13 @@ const form = useForm<ConfigRow, number>({
   }),
   idKey: 'id',
   rules,
-  // No `title` option: useForm captures it once, so the dialog would keep the
-  // language it was opened in. The dialog builds its own from `isEdit`.
+  // Computed, not `t(...)` directly: useForm reads the option on every render,
+  // so a string resolved here once would pin the dialog to the language the
+  // page was opened in.
+  title: {
+    create: computed(() => t('admin.sysConfig.addTitle')),
+    edit: computed(() => t('admin.sysConfig.editTitle'))
+  },
   api: { get: getConfig, add: addConfig, update: updateConfig },
   onSuccess: () => table.getList()
 })

--- a/src/views/admin/sys-dept/index.vue
+++ b/src/views/admin/sys-dept/index.vue
@@ -88,7 +88,7 @@
 
     <el-dialog
       v-model="form.visible"
-      :title="form.isEdit ? $t('admin.sysDept.editTitle') : $t('admin.sysDept.addTitle')"
+      :title="form.title"
       width="600px"
       :close-on-click-modal="false"
       @closed="form.reset"
@@ -214,9 +214,7 @@ const parent = useTreePicker<SysDept>({
   api: () => getDeptList(),
   idKey: 'deptId',
   labelKey: 'deptName',
-  // Read once, the way useForm's rules were before they took a ref: the label
-  // a reader already has on screen keeps the language the page was opened in.
-  rootLabel: t('admin.sysDept.rootCategory'),
+  rootLabel: computed(() => t('admin.sysDept.rootCategory')),
   rootId: ROOT_ID
 })
 
@@ -250,8 +248,13 @@ const form = useForm<SysDept, number>({
   }),
   idKey: 'deptId',
   rules,
-  // No `title` option: useForm captures it once, so the dialog would keep the
-  // language it was opened in. The dialog builds its own from `isEdit`.
+  // Computed, not `t(...)` directly: useForm reads the option on every render,
+  // so a string resolved here once would pin the dialog to the language the
+  // page was opened in.
+  title: {
+    create: computed(() => t('admin.sysDept.addTitle')),
+    edit: computed(() => t('admin.sysDept.editTitle'))
+  },
   api: {
     get: getDeptForForm,
     add: addDept,

--- a/src/views/admin/sys-menu/index.vue
+++ b/src/views/admin/sys-menu/index.vue
@@ -128,7 +128,7 @@
 
     <el-dialog
       v-model="form.visible"
-      :title="form.isEdit ? $t('admin.sysMenu.editTitle') : $t('admin.sysMenu.addTitle')"
+      :title="form.title"
       width="820px"
       :close-on-click-modal="false"
       @closed="form.reset"
@@ -346,9 +346,7 @@ const parent = useTreePicker<SysMenu>({
   api: () => listMenu({}),
   idKey: 'menuId',
   labelKey: 'title',
-  // Read once, the way useForm's rules were before they took a ref: the label
-  // a reader already has on screen keeps the language the page was opened in.
-  rootLabel: t('admin.sysMenu.rootCategory'),
+  rootLabel: computed(() => t('admin.sysMenu.rootCategory')),
   rootId: ROOT_ID
 })
 
@@ -401,8 +399,13 @@ const form = useForm<SysMenu, number>({
   }),
   idKey: 'menuId',
   rules,
-  // No `title` option: useForm captures it once, so the dialog would keep the
-  // language it was opened in. The dialog builds its own from `isEdit`.
+  // Computed, not `t(...)` directly: useForm reads the option on every render,
+  // so a string resolved here once would pin the dialog to the language the
+  // page was opened in.
+  title: {
+    create: computed(() => t('admin.sysMenu.addTitle')),
+    edit: computed(() => t('admin.sysMenu.editTitle'))
+  },
   api: {
     get: getMenu,
     add: addMenu,

--- a/src/views/admin/sys-role/index.vue
+++ b/src/views/admin/sys-role/index.vue
@@ -97,7 +97,7 @@
     <!-- Create / edit, with the menu tree -->
     <el-dialog
       v-model="roleForm.visible"
-      :title="roleForm.isEdit ? $t('admin.sysRole.editTitle') : $t('admin.sysRole.addTitle')"
+      :title="roleForm.title"
       width="560px"
       :close-on-click-modal="false"
       @closed="roleForm.reset"
@@ -310,8 +310,13 @@ const roleForm = useForm<SysRole, number>({
   }),
   idKey: 'roleId',
   rules,
-  // No `title` option: useForm captures it once, so the dialog would keep the
-  // language it was opened in. The dialog builds its own from `isEdit`.
+  // Computed, not `t(...)` directly: useForm reads the option on every render,
+  // so a string resolved here once would pin the dialog to the language the
+  // page was opened in.
+  title: {
+    create: computed(() => t('admin.sysRole.addTitle')),
+    edit: computed(() => t('admin.sysRole.editTitle'))
+  },
   api: {
     get: getRole,
     add: model => addRole({ ...model, menuIds: checkedMenuIds() }),

--- a/src/views/admin/sys-user/index.vue
+++ b/src/views/admin/sys-user/index.vue
@@ -172,7 +172,7 @@
     <!-- Create / edit -->
     <el-dialog
       v-model="userForm.visible"
-      :title="userForm.isEdit ? $t('admin.sysUser.editTitle') : $t('admin.sysUser.addTitle')"
+      :title="userForm.title"
       width="640px"
       :close-on-click-modal="false"
       @closed="userForm.reset"
@@ -522,8 +522,13 @@ const userForm = useForm<SysUser, number>({
   idKey: 'userId',
   rules: userRules,
   api: { get: getUser, add: addUser, update: updateUser },
-  // No `title` option: useForm captures it once, so the dialog would keep the
-  // language it was opened in. The dialog builds its own from `isEdit`.
+  // Computed, not `t(...)` directly: useForm reads the option on every render,
+  // so a string resolved here once would pin the dialog to the language the
+  // page was opened in.
+  title: {
+    create: computed(() => t('admin.sysUser.addTitle')),
+    edit: computed(() => t('admin.sysUser.editTitle'))
+  },
   onSuccess: () => table.getList()
 })
 

--- a/src/views/dev-tools/gen/editTable.vue
+++ b/src/views/dev-tools/gen/editTable.vue
@@ -219,10 +219,17 @@ const info = ref<GenTable>({})
 const basicForm = ref<{ validate: () => Promise<unknown> }>()
 const genForm = ref<{ validate: () => Promise<unknown> }>()
 
-/** The relation pickers offer the columns of whichever table a row points at. */
+/**
+ * The relation pickers offer the columns of whichever table a row points at.
+ *
+ * Empty rather than a 请选择 placeholder row: the two el-options below bind
+ * `:value="column.jsonField"`, which that row does not carry, so it rendered an
+ * option whose value was undefined and Element Plus warned on every one of them.
+ * el-select shows its own placeholder when it has no options.
+ */
 const attachForeignColumns = (row: GenTable) => {
   const target = tableTree.value.find(item => item.tableName === row.fkTableName)
-  row.fkCol = target?.columns ?? [{ columnId: 0, columnName: '请选择' }]
+  row.fkCol = target?.columns ?? []
 }
 
 const load = async() => {
@@ -234,7 +241,11 @@ const load = async() => {
       getGenTable(tableId),
       getDictOptionselect()
     ])
-    tableTree.value = [{ tableId: 0, className: '请选择' }, ...(tree.data ?? [])]
+    // No placeholder row: el-select already has a placeholder, and this one
+    // carried `className` while the option below binds `tableName` -- so every
+    // render rejected an undefined `value`. Same shape as the fkCol default
+    // above, and the other half of the same fault.
+    tableTree.value = tree.data ?? []
     columns.value = detail.data?.list ?? []
     // The three flags arrive as booleans and the radio groups work in strings
     const loaded = (detail.data?.info ?? {}) as GenTable

--- a/tests/e2e/mocked/gen.spec.ts
+++ b/tests/e2e/mocked/gen.spec.ts
@@ -256,4 +256,28 @@ test.describe('dev-tools editTable', () => {
     // Strings in the radio groups, booleans on the wire
     expect(typeof sent.isAuth).toBe('boolean')
   })
+
+  test('a column with no relation table offers no key to pick', async({ page }) => {
+    // The fallback used to be a synthetic `{ columnId: 0, columnName: '请选择' }`
+    // row, and the two pickers below it bind :value="column.jsonField" -- which
+    // that row does not carry. So each rendered one option whose value was
+    // undefined: blank, because the option's own slot prints jsonField too, and
+    // selectable, which would have written undefined onto the record. Element
+    // Plus reported it, on every render, as `Invalid prop: type check failed for
+    // prop "value"`.
+    //
+    // el-select has a placeholder of its own, so nothing was gained by it.
+    await installApiMocks(page)
+
+    await page.goto('/#/dev-tools/editTable?tableId=1')
+    await page.waitForSelector('.el-table')
+
+    const cell = page.locator('.el-table__body .el-table__row').first().locator('td').nth(15)
+    await expect(cell.locator('.el-select__placeholder')).toHaveText('请选择')
+    await cell.locator('.el-select').click()
+
+    const dropdown = page.locator('.el-select-dropdown:visible')
+    await expect(dropdown).toBeVisible()
+    await expect(dropdown.locator('.el-select-dropdown__item')).toHaveCount(0)
+  })
 })

--- a/tests/e2e/mocked/i18n.spec.ts
+++ b/tests/e2e/mocked/i18n.spec.ts
@@ -138,17 +138,6 @@ test.describe('switching language', () => {
     await expect(errors.filter({ hasText: 'Username is required' })).toHaveCount(1)
   })
 
-  /**
-   * The whole confirm dialog, not just the sentence the page passes in.
-   *
-   * useRemove owned four strings: the body, the title, and both buttons. Only
-   * the body could be overridden, so a migrated page reached English there
-   * while '提示' / '确定' / '取消' stayed written into the composable -- an
-   * English question inside a Chinese box, on every list page in the
-   * application. sys-config is used because it takes the default body too, so
-   * this covers all four at once.
-   */
-
   test('keeps the language across a reload', async({ page }) => {
     await openList(page)
     await switchTo(page, 'English')
@@ -254,6 +243,85 @@ test.describe('switching language', () => {
     // And the interface is still the language it was, rather than half-switched.
     await expect(page.locator('.sidebar-container')).toContainText('User')
     await expect(page.locator('.sidebar-container')).not.toContainText('User Management')
+  })
+
+  /**
+   * The whole confirm dialog, not just the sentence the page passes in.
+   *
+   * useRemove owned four strings: the body, the title, and both buttons. Only
+   * the body could be overridden, so a migrated page reached English there
+   * while '提示' / '确定' / '取消' stayed written into the composable -- an
+   * English question inside a Chinese box, on every list page in the
+   * application. sys-config is used because it takes the default body too, so
+   * this covers all four at once.
+   */
+  test('asks to delete in English, box and buttons included', async({ page }) => {
+    await page.goto('/#/admin/sys-config')
+    await expect(page.locator('.el-table').first()).toBeVisible({ timeout: 15000 })
+
+    await switchTo(page, 'English')
+    await page.getByRole('row', { name: /应用名称/ }).getByRole('button', { name: 'Delete' }).click()
+
+    const box = page.locator('.el-message-box')
+    await expect(box).toBeVisible()
+    await expect(box.locator('.el-message-box__title')).toHaveText('Notice')
+    await expect(box.locator('.el-message-box__message')).toHaveText('Delete the selected record?')
+    await expect(box.getByRole('button', { name: 'OK' })).toBeVisible()
+    await expect(box.getByRole('button', { name: 'Cancel' })).toBeVisible()
+
+    // And nothing else in it either -- the four assertions above name the parts
+    // that were wrong once, this one catches the next one.
+    expect(await box.innerText(), 'Chinese left in the dialog').not.toMatch(/[\u4e00-\u9fa5]/)
+
+    await box.getByRole('button', { name: 'OK' }).click()
+    await expect(page.locator('.el-message--success')).toContainText('Deleted successfully')
+  })
+
+  test('renames the picker root that no API sends', async({ page }) => {
+    // Every branch in the parent picker comes from the department endpoint and
+    // is Chinese in either language. The root above them is the one node this
+    // repository writes, so it is the one node a switch has to repaint -- and
+    // useTreePicker read it once, when the page was set up, which pinned it to
+    // whichever language that was.
+    //
+    // The tree behind it is fetched once and cached, and reopening the dialog
+    // does not re-run setup, so nothing here refetches or rebuilds: the label
+    // has to follow on its own.
+    await page.goto('/#/admin/sys-dept')
+    await expect(page.locator('.el-table').first()).toBeVisible({ timeout: 15000 })
+
+    const dialog = page.locator('.el-dialog:visible')
+    const root = () => dialog.locator('.el-form-item').first().locator('.el-select__wrapper')
+
+    await page.getByRole('button', { name: '新增', exact: true }).first().click()
+    await expect(dialog).toContainText('添加部门')
+    await expect(root()).toHaveText('主类目')
+
+    await dialog.getByRole('button', { name: '取 消' }).click()
+    await expect(dialog).toHaveCount(0)
+
+    await switchTo(page, 'English')
+    await page.getByRole('button', { name: 'Add', exact: true }).first().click()
+
+    await expect(dialog).toContainText('Add Department')
+    await expect(root()).toHaveText('Root')
+  })
+
+  test('retitles a dialog that is already open', async({ page }) => {
+    // The title moved back into useForm's `title` option in this batch. The
+    // option is read on every render, so a page that passes a computed follows
+    // the switch -- a page that passes a plain t(...) would sit here in the old
+    // language with the rest of the dialog in the new one.
+    await openList(page)
+    await page.getByRole('button', { name: '新增', exact: true }).click()
+
+    const dialog = page.locator('.el-dialog:visible')
+    await expect(dialog.locator('.el-dialog__title')).toHaveText('添加用户')
+
+    await page.locator('#lang-select').dispatchEvent('click')
+    await page.getByRole('menuitem', { name: 'English', exact: true }).click()
+
+    await expect(dialog.locator('.el-dialog__title')).toHaveText('Add User')
   })
 
   test('switches back', async({ page }) => {

--- a/tests/e2e/mocked/sys-dept.spec.ts
+++ b/tests/e2e/mocked/sys-dept.spec.ts
@@ -143,6 +143,46 @@ test.describe('sys-dept', () => {
       .locator('.el-select__wrapper')).toHaveText('研发部')
   })
 
+  /**
+   * The parent picker's `data` prop, which Element Plus declares as an Array.
+   *
+   * useTreePicker returned a bare object holding a computed, so property access
+   * -- `parent.options`, which is how both tree pages read it -- handed the
+   * template the ComputedRef rather than the array inside it. el-tree-select
+   * warned on every render: 18 times in one run of this file before it was
+   * fixed, 22 in sys-menu. Nothing else showed it, because Vue passes the value
+   * through after warning, so the picker worked and only the console said
+   * otherwise.
+   *
+   * Scoped to `prop "data"` deliberately. This page also logs three warnings
+   * about el-input-number's modelValue, where the sort field arrives from the
+   * list as the string "1" -- a real but separate defect, and a bare "no
+   * warnings at all" assertion here would be about that one instead.
+   */
+  test('hands the parent picker an array, not the computed wrapping it', async({ page }) => {
+    const warnings: string[] = []
+    page.on('console', message => {
+      if (message.text().includes('Invalid prop')) warnings.push(message.text())
+    })
+
+    await installApiMocks(page)
+
+    await page.goto('/#/admin/sys-dept')
+    await page.waitForSelector('.el-table')
+
+    // The picker is only mounted once a dialog opens
+    await page.getByRole('row', { name: /研发部/ }).getByRole('button', { name: '新增' }).click()
+    const dialog = page.getByRole('dialog').filter({ hasText: '添加部门' })
+    await expect(dialog).toBeVisible()
+    // Waited for rather than assumed: the warning is logged while the picker
+    // renders, so the assertion below has to run after it has.
+    await expect(dialog.locator('.el-form-item').filter({ hasText: '上级部门' })
+      .locator('.el-select__wrapper')).toHaveText('研发部')
+
+    const aboutData = warnings.filter(text => text.includes('prop "data"'))
+    expect(aboutData, aboutData[0] ?? '').toHaveLength(0)
+  })
+
   // The list sends status as a number, the dictionary keys on strings, and the
   // write endpoints want numbers back.
   test('submits status and sort as numbers', async({ page }) => {

--- a/tests/unit/composables/useForm.spec.ts
+++ b/tests/unit/composables/useForm.spec.ts
@@ -1,6 +1,7 @@
 import { computed, nextTick, ref } from 'vue'
 import type { FormRules } from 'element-plus'
 import { useForm } from '@/composables/useForm'
+import { i18n, setLocale } from '@/lang'
 import type { ApiResponse } from '@/types/api'
 import { deferred } from '../support/async'
 
@@ -146,6 +147,45 @@ describe('useForm', () => {
 
       await form.openEdit({ userId: 1 })
       expect(form.title).toBe('修改用户')
+    })
+
+    describe('the title in another language', () => {
+      afterEach(async() => { await setLocale('zh-CN') })
+
+      it('defaults to 新增 / 修改 in whichever language is current', async() => {
+        const form = useForm<User, number>({ defaultModel: defaultUser, idKey: 'userId' })
+
+        form.openCreate()
+        expect(form.title).toBe('新增')
+
+        await setLocale('en-US')
+        expect(form.title).toBe('Add')
+
+        await form.openEdit({ userId: 1 })
+        expect(form.title).toBe('Edit')
+      })
+
+      it('follows a computed title through a switch', async() => {
+        // The dialog stays open while the reader switches, so the title has to
+        // be re-read rather than captured when useForm was called. A page that
+        // passes a plain t(...) gets the frozen behaviour this guards against
+        // -- which is why the option takes a MaybeRef.
+        const form = useForm<User, number>({
+          defaultModel: defaultUser,
+          idKey: 'userId',
+          // What the five migrated pages pass, verbatim.
+          title: {
+            create: computed(() => i18n.global.t('admin.sysUser.addTitle')),
+            edit: computed(() => i18n.global.t('admin.sysUser.editTitle'))
+          }
+        })
+
+        form.openCreate()
+        expect(form.title).toBe('添加用户')
+
+        await setLocale('en-US')
+        expect(form.title).toBe('Add User')
+      })
     })
   })
 
@@ -390,6 +430,33 @@ describe('useForm', () => {
       await form.submit()
 
       expect(msgSuccess).toHaveBeenCalledWith('加了 bob')
+    })
+
+    it('translates the default toast rather than always saying 新增成功', async() => {
+      // The default is resolved inside submit(), so it follows a switch made
+      // long after the page was set up. Both branches are checked: the add and
+      // the edit toast come from two different keys and a migration that moved
+      // only one of them would still look right on the page it was tested on.
+      const add = vi.fn().mockResolvedValue(undefined)
+      const update = vi.fn().mockResolvedValue(undefined)
+      const form = useForm<User, number>({
+        defaultModel: defaultUser,
+        idKey: 'userId',
+        api: { add, update }
+      })
+
+      await setLocale('en-US')
+      try {
+        form.openCreate({ username: 'bob' })
+        await form.submit()
+        expect(msgSuccess).toHaveBeenLastCalledWith('Added successfully')
+
+        await form.openEdit({ userId: 1, username: 'bob' })
+        await form.submit()
+        expect(msgSuccess).toHaveBeenLastCalledWith('Saved successfully')
+      } finally {
+        await setLocale('zh-CN')
+      }
     })
 
     it('stays silent when successMessage is null', async() => {

--- a/tests/unit/composables/useRemove.spec.ts
+++ b/tests/unit/composables/useRemove.spec.ts
@@ -1,5 +1,6 @@
 import { nextTick } from 'vue'
 import { useRemove } from '@/composables/useRemove'
+import { setLocale } from '@/lang'
 import { deferred } from '../support/async'
 
 const confirm = vi.hoisted(() => vi.fn())
@@ -168,5 +169,74 @@ describe('useRemove', () => {
     await remove(1)
 
     expect(msgSuccess).not.toHaveBeenCalled()
+  })
+
+  /**
+   * The reason this batch exists.
+   *
+   * The confirmation body was the only part a page could pass in, so a
+   * translated page reached English there while the title and both buttons --
+   * written as '提示' / '确定' / '取消' inside the composable -- stayed Chinese.
+   * An English reader deleting a row met an English question in a Chinese
+   * dialog, on every list page in the application, including the ones already
+   * migrated.
+   */
+  describe('in English', () => {
+    const HAN = /[\u4e00-\u9fa5]/
+
+    beforeEach(async() => { await setLocale('en-US') })
+    afterEach(async() => { await setLocale('zh-CN') })
+
+    it('asks, titles and labels the dialog in English -- all four', async() => {
+      accepts()
+      const api = vi.fn().mockResolvedValue(undefined)
+      const { remove } = useRemove({ api })
+
+      await remove([4, 5])
+
+      const [body, title, options] = confirm.mock.calls[0]
+      expect(body).toBe('Delete the 2 selected records?')
+      expect(title).toBe('Notice')
+      expect(options.confirmButtonText).toBe('OK')
+      expect(options.cancelButtonText).toBe('Cancel')
+      expect(msgSuccess).toHaveBeenCalledWith('Deleted successfully')
+
+      // Named rather than positional, so a failure says which part is still
+      // Chinese instead of only that something is.
+      const parts = {
+        body,
+        title,
+        confirmButtonText: options.confirmButtonText,
+        cancelButtonText: options.cancelButtonText,
+        toast: vi.mocked(msgSuccess).mock.calls[0][0]
+      }
+      expect(Object.entries(parts).filter(([, text]) => HAN.test(String(text)))).toEqual([])
+    })
+
+    it('counts in the singular, which Chinese does not have to', async() => {
+      accepts()
+      const api = vi.fn().mockResolvedValue(undefined)
+      const { remove } = useRemove({ api })
+
+      await remove(7)
+
+      expect(confirm.mock.calls[0][0]).toBe('Delete the selected record?')
+    })
+
+    it('follows a switch made after the page was set up', async() => {
+      // useRemove is called once, when the page is created. Reading the
+      // strings there -- the obvious way to write it -- would pin every dialog
+      // the page ever opens to the language it was opened in.
+      await setLocale('zh-CN')
+      accepts()
+      const api = vi.fn().mockResolvedValue(undefined)
+      const { remove } = useRemove({ api })
+
+      await setLocale('en-US')
+      await remove(7)
+
+      expect(confirm.mock.calls[0][1]).toBe('Notice')
+      expect(confirm.mock.calls[0][0]).toBe('Delete the selected record?')
+    })
   })
 })

--- a/tests/unit/composables/useTreePicker.spec.ts
+++ b/tests/unit/composables/useTreePicker.spec.ts
@@ -1,0 +1,166 @@
+import { computed, defineComponent, h, isRef, ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { useTreePicker } from '@/composables/useTreePicker'
+import { i18n, setLocale } from '@/lang'
+import type { ApiResponse } from '@/types/api'
+import { flushPromises } from '../support/async'
+
+interface Dept {
+  deptId?: number
+  deptName?: string
+  children?: Dept[]
+}
+
+const tree: Dept[] = [
+  { deptId: 1, deptName: '研发部', children: [{ deptId: 3, deptName: '前端组' }] },
+  { deptId: 2, deptName: '测试部' }
+]
+
+const answers = (rows: Dept[]) =>
+  vi.fn().mockResolvedValue({ code: 200, msg: 'ok', data: rows } as ApiResponse<Dept[]>)
+
+const picker = (api = answers(tree), rootLabel: Parameters<typeof useTreePicker>[0]['rootLabel'] = '主类目') =>
+  useTreePicker<Dept>({ api, idKey: 'deptId', labelKey: 'deptName', rootLabel })
+
+/** Declares `data` the way el-tree-select does, so a wrong shape is reported. */
+const TreeSelectStub = defineComponent({
+  name: 'TreeSelectStub',
+  props: { data: { type: Array, default: () => [] }},
+  render() { return h('div') }
+})
+
+describe('useTreePicker', () => {
+  it('wraps the tree under a synthetic root once it has loaded', async() => {
+    const parent = picker()
+
+    // Before the fetch there is still a root to select, or a page could not
+    // create a top-level record while the request is in flight.
+    expect(parent.options).toEqual([{ deptId: 0, deptName: '主类目', children: [] }])
+
+    await parent.ensure()
+    expect(parent.options[0].children).toEqual(tree)
+  })
+
+  it('fetches once, and again only after invalidate', async() => {
+    const api = answers(tree)
+    const parent = picker(api)
+
+    await parent.ensure()
+    await parent.ensure()
+    expect(api).toHaveBeenCalledTimes(1)
+
+    parent.invalidate()
+    await parent.ensure()
+    expect(api).toHaveBeenCalledTimes(2)
+  })
+
+  it('shares one request between two dialogs opened at once', async() => {
+    const api = answers(tree)
+    const parent = picker(api)
+
+    await Promise.all([parent.ensure(), parent.ensure()])
+
+    expect(api).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the last good tree when the request fails', async() => {
+    const api = vi.fn().mockResolvedValueOnce({ code: 200, msg: 'ok', data: tree })
+    const parent = picker(api as never)
+    await parent.ensure()
+
+    api.mockRejectedValueOnce(new Error('500'))
+    parent.invalidate()
+    await parent.ensure()
+
+    // Emptying it would read as "this record has no parent"
+    expect(parent.options[0].children).toEqual(tree)
+  })
+
+  /**
+   * The returned object is reactive(), so `parent.options` is the array.
+   *
+   * It used to be returned bare, which meant property access handed the
+   * template the ComputedRef itself -- and el-tree-select, whose `data` prop
+   * declares an Array, logged `Invalid prop: type check failed for prop "data".
+   * Expected Array, got Object` on every render of both tree pages. The picker
+   * still worked, because Vue passes the value through after warning, so
+   * nothing but the console said anything was wrong.
+   *
+   * Which shape is right depends on the call site, not on taste: this one is
+   * read as `parent.options`, while useRemove, useExport and useDict are
+   * destructured and must stay bare refs.
+   */
+  describe('the shape it hands the template', () => {
+    it('is an array, not a ref', () => {
+      const parent = picker()
+
+      expect(isRef(parent.options)).toBe(false)
+      expect(Array.isArray(parent.options)).toBe(true)
+    })
+
+    it('passes a component prop declared as Array without a warning', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        const parent = picker()
+        // A plain object rather than defineComponent(): one component per file
+        // is a lint rule, and this host exists only to pass the prop.
+        mount({ render() { return h(TreeSelectStub, { data: parent.options }) } })
+
+        const invalid = warn.mock.calls
+          .map(call => String(call[0]))
+          .filter(text => text.includes('Invalid prop'))
+        expect(invalid).toEqual([])
+      } finally {
+        warn.mockRestore()
+      }
+    })
+
+    it('still updates after the tree lands, so reactive() did not snapshot it', async() => {
+      const parent = picker()
+      const seen: number[] = []
+
+      mount({
+        render() {
+          seen.push((parent.options[0].children ?? []).length)
+          return h(TreeSelectStub, { data: parent.options })
+        }
+      })
+
+      expect(seen).toEqual([0])
+      void parent.ensure()
+      await flushPromises()
+      expect(seen.at(-1)).toBe(tree.length)
+    })
+  })
+
+  describe('the root label', () => {
+    afterEach(async() => { await setLocale('zh-CN') })
+
+    it('still takes a plain string, for the pages not yet migrated', () => {
+      expect(picker(answers(tree), '主类目').options[0].deptName).toBe('主类目')
+    })
+
+    it('follows a ref, so it is not stranded in the language it was read in', () => {
+      const label = ref('主类目')
+      const parent = picker(answers(tree), label)
+
+      expect(parent.options[0].deptName).toBe('主类目')
+      label.value = 'Root'
+      expect(parent.options[0].deptName).toBe('Root')
+    })
+
+    it('follows the language when given the computed the pages pass', async() => {
+      // The synthetic root is the one node in the picker that is not a database
+      // record, so it is the one node a language switch has to repaint. Every
+      // branch under it comes from the API and changes on its own.
+      const parent = picker(
+        answers(tree),
+        computed(() => i18n.global.t('admin.sysDept.rootCategory'))
+      )
+      expect(parent.options[0].deptName).toBe('主类目')
+
+      await setLocale('en-US')
+      expect(parent.options[0].deptName).toBe('Root')
+    })
+  })
+})


### PR DESCRIPTION
Deleting a record in the English interface asked its question in English inside a dialog whose **title and both buttons were still Chinese**. `useRemove` owned those four strings; `useForm` owned the dialog titles and success toasts. Every list page inherits them — including the five translated in the last batch — so leaving this to the per-page batches would have meant each of them shipping the same half-translated dialog.

## Most of it needed no reactivity work

The strings live inside functions that run when the dialog opens or a submit lands, so reading them through `i18n.global.t` resolves them at that moment — the shape `utils/request.ts` already uses. Only two take `MaybeRef`, because a page passes them in and would otherwise freeze them at setup: `useForm`'s `title.create` / `title.edit`, and `useTreePicker`'s `rootLabel`.

Nothing was added to the packs for 提示 / 确定 / 取消 / 新增 / 修改 — `common.ts` already carries those exact strings.

## Two long-standing warnings, measured rather than assumed

`useTreePicker` stops returning a bare object. It was **the only composable used through property access** (`parent.options`) without a `reactive()` wrapper, so the template handed `el-tree-select` a `ComputedRef` instead of an array and Vue rejected the prop on every render. The others that return bare objects are destructured, which is the case where a bare ref is correct.

The generator page had **two** placeholder rows, not one: `fkCol` fell back to a row carrying `columnName` while its options bind `jsonField`, and `tableTree` was seeded with a row carrying `className` while its options bind `tableName`.

| | before | after |
|---|---|---|
| sys-dept, `ElTreeSelect` `data` | 18 | 0 |
| sys-menu, same | 22 | 0 |
| generator, `ElOption` `value` | 48 | 0 |

Fixing only the first placeholder gives 48 to 16; both are needed to reach zero.

## Verification

Every assertion is anchored by reverting its fix — restoring a literal turns the matching case red, and the `useTreePicker` suite loses 8 of its 10 the moment the wrapper comes off, one of them by catching Vue's own warning rather than inspecting a value.

Two cases assert a *count* of zero warnings. A warning nobody reads is indistinguishable from no warning at all, so the count is what keeps them from coming back. The sys-dept one is narrowed to `prop "data"` because that page also warns about an unrelated `ElInputNumber` — an assertion covering both would fail for someone else's reason.

One case had to be rewritten after it disagreed with the implementation: `el-tree-select` does not repaint its selected label when `data` changes, so "switch language with the dialog open" could never pass. Reopening the dialog is the path a user actually takes.

Full suite: **218 passed, 0 failed**, with `git rev-parse HEAD` identical before and after the run.