### PR TITLE
refactor🎨: translate the remaining pages (P1 batches 2, 3 and 4)

### DIFF
--- a/src/lang/en-US/admin/dict.ts
+++ b/src/lang/en-US/admin/dict.ts
@@ -1,0 +1,66 @@
+export default {
+  type: {
+    dictName: 'Dictionary Name',
+    dictNamePlaceholder: 'Please enter dictionary name',
+    dictType: 'Dictionary Type',
+    dictTypePlaceholder: 'Please enter dictionary type',
+    status: 'Status',
+    statusPlaceholder: 'Dictionary status',
+    dictId: 'ID',
+    remark: 'Remark',
+
+    addTitle: 'Add Dictionary Type',
+    editTitle: 'Edit Dictionary Type',
+    remarkPlaceholder: 'Please enter content',
+
+    // Pluralised, which the Chinese does not need. The page passes the count as
+    // the plural choice as well as a named value.
+    removeConfirm: 'Delete the selected dictionary type? | Delete the {count} selected dictionary types?',
+
+    exportFilename: 'Dictionary Types',
+    exportHeader: {
+      dictId: 'ID',
+      dictName: 'Dictionary Name',
+      dictType: 'Dictionary Type',
+      status: 'Status',
+      remark: 'Remark'
+    },
+
+    rules: {
+      dictName: 'Dictionary name is required',
+      dictType: 'Dictionary type is required'
+    }
+  },
+
+  data: {
+    dictName: 'Dictionary Name',
+    dictLabel: 'Dictionary Label',
+    dictLabelPlaceholder: 'Please enter dictionary label',
+    status: 'Status',
+    statusPlaceholder: 'Data status',
+    dictCode: 'ID',
+    dictValue: 'Dictionary Value',
+    dictSort: 'Order',
+    remark: 'Remark',
+
+    addTitle: 'Add Dictionary Data',
+    editTitle: 'Edit Dictionary Data',
+    dictType: 'Dictionary Type',
+    label: 'Data Label',
+    labelPlaceholder: 'Please enter data label',
+    value: 'Data Value',
+    valuePlaceholder: 'Please enter data value',
+    displaySort: 'Display Order',
+    remarkPlaceholder: 'Please enter content',
+
+    // 'entry' rather than a plural of 'Dictionary Data', which has none: the
+    // sentence counts rows, and English has to name what a row is.
+    removeConfirm: 'Delete the selected dictionary entry? | Delete the {count} selected dictionary entries?',
+
+    rules: {
+      dictLabel: 'Data label is required',
+      dictValue: 'Data value is required',
+      dictSort: 'Display order is required'
+    }
+  }
+}

--- a/src/lang/en-US/admin/index.ts
+++ b/src/lang/en-US/admin/index.ts
@@ -3,5 +3,21 @@ import sysRole from './sys-role'
 import sysMenu from './sys-menu'
 import sysConfig from './sys-config'
 import sysDept from './sys-dept'
+import sysPost from './sys-post'
+import dict from './dict'
+import sysApi from './sys-api'
+import sysOperLog from './sys-oper-log'
+import sysLoginLog from './sys-login-log'
 
-export default { sysUser, sysRole, sysMenu, sysConfig, sysDept }
+export default {
+  sysUser,
+  sysRole,
+  sysMenu,
+  sysConfig,
+  sysDept,
+  sysPost,
+  dict,
+  sysApi,
+  sysOperLog,
+  sysLoginLog
+}

--- a/src/lang/en-US/admin/sys-api.ts
+++ b/src/lang/en-US/admin/sys-api.ts
@@ -1,0 +1,29 @@
+export default {
+  title: 'Title',
+  titlePlaceholder: 'Please enter title',
+  path: 'Path',
+  pathPlaceholder: 'Please enter path',
+  selectPlaceholder: 'Please select',
+  type: 'Type',
+
+  // 'API' per the glossary, which keeps 'Interface' out of a product where it
+  // already means something else.
+  api: 'API',
+  none: 'None',
+  // No trailing space after the colon: the Chinese full-width colon carries its
+  // own, English needs one written in.
+  peekHandle: 'Handle: {value}',
+  peekType: 'Type: {value}',
+  peekTitle: 'Title: {value}',
+
+  addTitle: 'Add API',
+  editTitle: 'Edit API',
+  typePlaceholder: 'Please select a type',
+  actionPlaceholder: 'Please select a method',
+
+  rules: {
+    handle: 'Handle is required',
+    title: 'Title is required',
+    type: 'Type is required'
+  }
+}

--- a/src/lang/en-US/admin/sys-config.ts
+++ b/src/lang/en-US/admin/sys-config.ts
@@ -42,5 +42,46 @@ export default {
     configKey: 'Parameter key is required',
     configValue: 'Parameter value is required',
     isFrontend: 'Show in frontend is required'
+  },
+
+  set: {
+    sidebarTitle: 'System Settings',
+    sidebarSub: 'Basic information and appearance',
+    basic: 'Basic Information',
+    basicSub: 'Name, logo, password',
+    appearance: 'Appearance',
+    appearanceSub: 'Skin and theme',
+
+    basicTitle: 'Basic System Information',
+    basicDesc: 'Set the system name, the logo and the default user password',
+    logoEmpty: 'No logo',
+    logoName: 'System Logo',
+    logoHint: '200×200 recommended, JPG or PNG, up to 2MB',
+    upload: 'Upload Image',
+    appName: 'System Name',
+    appNamePlaceholder: 'Please enter system name',
+    initPassword: 'Initial User Password',
+    initPasswordPlaceholder: 'Please enter the initial password',
+
+    appearanceDesc: 'Adjust the skin and the sidebar theme',
+    skin: 'Skin',
+    skinPlaceholder: 'Please select a skin',
+    skinBlue: 'Blue',
+    sideTheme: 'Sidebar Theme',
+    sideThemePlaceholder: 'Please select a sidebar theme',
+    themeHint: 'Click to switch theme',
+    themeDark: 'Dark Theme',
+    themeLight: 'Light Theme',
+
+    save: 'Save Settings',
+    // 'Saved', not 'Updated': the same wording the composables use for a
+    // persisted change.
+    saveOk: 'Saved successfully',
+    logoTooLarge: 'The file is larger than 2MB',
+
+    rules: {
+      appName: 'Please enter system name',
+      initPassword: 'Please enter the initial password'
+    }
   }
 }

--- a/src/lang/en-US/admin/sys-login-log.ts
+++ b/src/lang/en-US/admin/sys-login-log.ts
@@ -1,0 +1,22 @@
+export default {
+  username: 'Username',
+  usernamePlaceholder: 'Please enter username',
+  status: 'Status',
+  statusPlaceholder: 'Login status',
+  ipaddr: 'IP Address',
+  ipaddrPlaceholder: 'Please enter IP address',
+
+  msg: 'Type',
+  // No trailing space after the colon: the Chinese full-width colon carries its
+  // own, English needs one written in.
+  peekLocation: 'Location: {value}',
+  peekBrowser: 'Browser: {value}',
+  peekOs: 'OS: {value}',
+  // 'Platform', not a translation of 固件 (firmware): the field behind it is
+  // loginLog.platform, and the Chinese label misnames it. Fixing the Chinese is
+  // a separate change -- PRD R5 keeps it as it renders today.
+  peekPlatform: 'Platform: {value}',
+  loginTime: 'Login Time',
+
+  removeConfirm: 'Delete the selected login log? | Delete the {count} selected login logs?'
+}

--- a/src/lang/en-US/admin/sys-oper-log.ts
+++ b/src/lang/en-US/admin/sys-oper-log.ts
@@ -1,0 +1,56 @@
+export default {
+  operUrl: 'Request URL',
+  operUrlPlaceholder: 'Please enter request URL',
+  status: 'Status',
+  statusPlaceholder: 'Operation status',
+  // 操作时间 and 操作日期 are two spellings of one thing -- the picker labels
+  // the range with the first, the column heads with the second -- and English
+  // has no matching pair. Both keys stay so the Chinese keeps both spellings.
+  operTime: 'Operated At',
+  rangeSeparator: 'to',
+  startDate: 'Start date',
+  endDate: 'End date',
+
+  clean: 'Clear',
+
+  operId: 'ID',
+  request: 'Request',
+  // No trailing space after the colon: the Chinese full-width colon carries its
+  // own, English needs one written in.
+  peekHost: 'Host: {value}',
+  peekLocation: 'Location: {value}',
+  peekLatency: 'Duration: {value}',
+  operName: 'Operator',
+  operDate: 'Operated At',
+  detail: 'Detail',
+
+  detailTitle: 'Operation Log Detail',
+  detailUrl: 'Request URL',
+  loginInfo: 'Login Info',
+  requestMethod: 'Method',
+  latency: 'Duration',
+  module: 'Module',
+  operStatus: 'Operation Status',
+  operParam: 'Request Parameters',
+  jsonResult: 'Response Parameters',
+  // Same word as common.close; only the Chinese spacing differs.
+  dialogClose: 'Close',
+
+  removeConfirm: 'Delete the selected operation log? | Delete the {count} selected operation logs?',
+  cleanConfirm: 'Clear every operation log? This cannot be undone.',
+  cleanOk: 'Cleared',
+
+  exportFilename: 'Operation Logs',
+  exportHeader: {
+    operId: 'ID',
+    module: 'Module',
+    businessType: 'Operation Type',
+    operName: 'Operator',
+    operIp: 'Host',
+    operLocation: 'Location',
+    requestMethod: 'Method',
+    operUrl: 'Request URL',
+    status: 'Status',
+    operDate: 'Operated At'
+  }
+}

--- a/src/lang/en-US/admin/sys-post.ts
+++ b/src/lang/en-US/admin/sys-post.ts
@@ -1,0 +1,39 @@
+export default {
+  // 'Position', never 'Post': the glossary settles it, because Post reads as a
+  // message or as mailing before it reads as a job.
+  postCode: 'Position Code',
+  postCodePlaceholder: 'Please enter position code',
+  postName: 'Position Name',
+  postNamePlaceholder: 'Please enter position name',
+  status: 'Status',
+  statusPlaceholder: 'Position status',
+
+  postId: 'Position ID',
+  postSort: 'Order',
+
+  addTitle: 'Add Position',
+  editTitle: 'Edit Position',
+  // The Chinese distinguishes 请输入岗位编码 from 请输入编码名称; English does
+  // not, and inventing a difference here would only puzzle the reader. Both
+  // keys stay, so the Chinese keeps its two spellings.
+  codeNamePlaceholder: 'Please enter position code',
+  sort: 'Display Order',
+  postStatus: 'Position Status',
+  remark: 'Remark',
+  remarkPlaceholder: 'Please enter content',
+
+  exportFilename: 'Position Management',
+  exportHeader: {
+    postId: 'Position ID',
+    postCode: 'Position Code',
+    postName: 'Position Name',
+    sort: 'Order',
+    createdAt: 'Created At'
+  },
+
+  rules: {
+    postName: 'Position name is required',
+    postCode: 'Position code is required',
+    sort: 'Display order is required'
+  }
+}

--- a/src/lang/en-US/demo.ts
+++ b/src/lang/en-US/demo.ts
@@ -1,0 +1,17 @@
+export default {
+  name: 'Name',
+  namePlaceholder: 'Please enter a name',
+  code: 'Code',
+  codePlaceholder: 'Please enter a code',
+  price: 'Price',
+  status: 'Status',
+  statusPlaceholder: 'Please select a status',
+  normal: 'Normal',
+  disabled: 'Disabled',
+  remark: 'Remark',
+  remarkPlaceholder: 'Please enter a description',
+  rules: {
+    name: 'Name is required',
+    code: 'Code is required'
+  }
+}

--- a/src/lang/en-US/dev-tools/basic-info-form.ts
+++ b/src/lang/en-US/dev-tools/basic-info-form.ts
@@ -1,0 +1,29 @@
+export default {
+  // 数据表名称 here and 表名称 on the list page name the same thing
+  tableName: 'Table Name',
+  tableNameTip: 'The database table name, used by gorm for table(). ⚠️It must be snake_case.',
+  tableNamePlaceholder: 'Please enter table name',
+
+  tableComment: 'Menu Name',
+  tableCommentTip: 'The database table name that was synced; used as the menu name when the configuration data is generated',
+  tableCommentPlaceholder: 'Please enter menu name',
+
+  className: 'Struct Model Name',
+  classNameTip: 'The struct model name, used for the struct definition in the generated code',
+  classNamePlaceholder: 'Please enter',
+
+  functionAuthor: 'Author Name',
+  functionAuthorPlaceholder: 'Please enter author name',
+
+  remark: 'Remark',
+
+  rules: {
+    tableName: 'Please enter table name',
+    tableNamePattern: 'Lowercase letters only, e.g. sys_demo',
+    tableComment: 'Please enter menu name',
+    className: 'Please enter model name',
+    classNamePattern: 'Must start with an uppercase letter, e.g. SysDemo',
+    functionAuthor: 'Please enter author',
+    functionAuthorPattern: 'Letters a-z or A-Z only'
+  }
+}

--- a/src/lang/en-US/dev-tools/edit-table.ts
+++ b/src/lang/en-US/dev-tools/edit-table.ts
@@ -1,0 +1,50 @@
+export default {
+  tabBasic: 'Basic Information',
+  tabColumns: 'Field Information',
+  tabGen: 'Generation Information',
+
+  hiddenColumns: '⚠️The id, create_by, update_by, created_at, updated_at and deleted_at columns are hidden from this list',
+
+  // A row ordinal, not a key: 'No.' rather than the glossary's 'ID'
+  index: 'No.',
+  columnName: 'Column Name',
+  columnComment: 'Description',
+  // 物理类型 holds the SQL declaration (varchar(64), bigint). 'DB Type' says
+  // that to a developer; 'Physical Type' is a literal that only means something
+  // to someone who already knows the Chinese.
+  columnType: 'DB Type',
+  goType: 'Go Type',
+  goField: 'Go Field',
+  jsonField: 'JSON Field',
+
+  isInsert: 'Edit',
+  isList: 'List',
+  isListTip: 'Whether the column appears in the list; ticked means it does',
+  isQuery: 'Query',
+  isQueryTip: 'Whether the column is a search condition; ticked means it is',
+  queryType: 'Query Type',
+  isRequired: 'Required',
+
+  htmlType: 'Display Type',
+  // The stored values are input / select / radio / textarea, so the labels are
+  // the control names a developer reads in the generated template
+  htmlTypes: {
+    input: 'Input',
+    select: 'Select',
+    radio: 'Radio',
+    textarea: 'Textarea'
+  },
+
+  dictType: 'Dictionary Type',
+  fkTableName: 'Relation Table',
+  // 关系表key / 关系表value pick the columns used as an option's value and
+  // label, so 'Relation Table Key' would be both longer and less accurate
+  fkLabelId: 'Relation Key',
+  fkLabelName: 'Relation Value',
+  selectPlaceholder: 'Please select',
+
+  back: 'Back',
+  submit: 'Submit',
+  validationFailed: 'Some fields are not valid. Please check the form before submitting.',
+  saveSuccess: 'Saved successfully'
+}

--- a/src/lang/en-US/dev-tools/gen-info-form.ts
+++ b/src/lang/en-US/dev-tools/gen-info-form.ts
@@ -1,0 +1,41 @@
+export default {
+  tplCategory: 'Generation Template',
+  tplCrud: 'Relational Table (CRUD)',
+
+  // The Go project generates into app/<name>/, so 'App Name' names the thing
+  // the reader will go looking for
+  packageName: 'App Name',
+  packageNameTip: 'The application name -- which app under the app folder this feature is generated into. Default: admin',
+
+  businessName: 'Business Name',
+  businessNameTip: 'The feature name in English, e.g. user',
+
+  functionName: 'Feature Description',
+  functionNameTip: 'The table comment synced from the database, used as the class description, e.g. User',
+
+  moduleName: 'API Path',
+  moduleNameTip: "The API path, e.g. api/v1/{'{'}sys-user{'}'}",
+
+  otherInfo: 'Other Information',
+  treeCode: 'Tree Code Field',
+  treeCodeTip: 'The name of the code field the tree displays, e.g. dept_id',
+  treeParentCode: 'Tree Parent Code Field',
+  treeParentCodeTip: 'The name of the parent code field the tree displays, e.g. parent_Id',
+  treeName: 'Tree Name Field',
+  treeNameTip: 'The name of the field a tree node displays, e.g. dept_name',
+  selectPlaceholder: 'Please select',
+
+  // The Chinese messages name fields the form no longer has (生成包路径 for
+  // 应用名, 生成模块名 for 接口路径); the English keeps that mismatch rather
+  // than quietly fixing one language and not the other
+  rules: {
+    tplCategory: 'Please select a generation template',
+    packageName: 'Please enter the package path',
+    packageNamePattern: 'Lowercase letters only, e.g. system',
+    moduleName: 'Please enter the module name',
+    moduleNamePattern: 'Lowercase letters only, e.g. sys-demo',
+    businessName: 'Please enter the business name',
+    businessNamePattern: 'Must start with a letter; only a-z and A-Z are allowed',
+    functionName: 'Please enter the function name'
+  }
+}

--- a/src/lang/en-US/dev-tools/gen.ts
+++ b/src/lang/en-US/dev-tools/gen.ts
@@ -1,0 +1,26 @@
+export default {
+  tableName: 'Table Name',
+  tableNamePlaceholder: 'Please enter table name',
+  tableComment: 'Menu Name',
+  tableCommentPlaceholder: 'Please enter menu name',
+
+  import: 'Import',
+
+  // 'ID' per the glossary, which maps 编号 / 编码 / 序号-as-a-key onto one word
+  tableId: 'ID',
+  className: 'Model Name',
+
+  // 编辑 here and 修改 elsewhere are the same action in English
+  edit: 'Edit',
+  preview: 'Preview',
+  moreActions: 'More actions',
+  generateToProject: 'Generate into Project',
+  generateConfig: 'Generate Configuration',
+  generateMigration: 'Generate Migration Script',
+
+  previewTitle: 'Code Preview',
+
+  // Two forms, chosen by count -- the Chinese needs only one
+  deleteConfirm: 'Delete the generator configuration for the selected table? | Delete the generator configuration for the {count} selected tables?',
+  generated: 'Generated'
+}

--- a/src/lang/en-US/dev-tools/index.ts
+++ b/src/lang/en-US/dev-tools/index.ts
@@ -1,0 +1,6 @@
+import gen from './gen'
+import editTable from './edit-table'
+import basicInfoForm from './basic-info-form'
+import genInfoForm from './gen-info-form'
+
+export default { gen, editTable, basicInfoForm, genInfoForm }

--- a/src/lang/en-US/index.ts
+++ b/src/lang/en-US/index.ts
@@ -1,5 +1,8 @@
 import common from './common'
 import layout from './layout'
+import profile from './profile'
+import sysTools from './sys-tools'
+import demo from './demo'
 import route from './route'
 import components from './components'
 import login from './login'
@@ -15,4 +18,4 @@ import dict from './dict'
  * Unlike zh-CN this does carry menu and dict: those are the translations of
  * text the backend only ever sends in Chinese.
  */
-export default { common, layout, route, components, login, dashboard, admin, composables, menu, dict }
+export default { common, demo, sysTools, profile, layout, route, components, login, dashboard, admin, composables, menu, dict }

--- a/src/lang/en-US/index.ts
+++ b/src/lang/en-US/index.ts
@@ -3,6 +3,8 @@ import layout from './layout'
 import profile from './profile'
 import sysTools from './sys-tools'
 import demo from './demo'
+import devTools from './dev-tools'
+import schedule from './schedule'
 import route from './route'
 import components from './components'
 import login from './login'
@@ -18,4 +20,4 @@ import dict from './dict'
  * Unlike zh-CN this does carry menu and dict: those are the translations of
  * text the backend only ever sends in Chinese.
  */
-export default { common, demo, sysTools, profile, layout, route, components, login, dashboard, admin, composables, menu, dict }
+export default { common, schedule, devTools, demo, sysTools, profile, layout, route, components, login, dashboard, admin, composables, menu, dict }

--- a/src/lang/en-US/profile.ts
+++ b/src/lang/en-US/profile.ts
@@ -1,0 +1,59 @@
+export default {
+  title: 'Profile',
+  username: 'Username',
+  phone: 'Phone Number',
+  email: 'Email',
+  dept: 'Department',
+  role: 'Roles',
+  createdAt: 'Created',
+  noRole: 'None',
+
+  basic: 'Basic Information',
+  tabs: {
+    info: 'Basic Information',
+    password: 'Change Password'
+  },
+
+  info: {
+    nickName: 'Nickname',
+    phone: 'Phone Number',
+    email: 'Email',
+    sex: 'Gender',
+    male: 'Male',
+    female: 'Female',
+    rules: {
+      nickName: 'Nickname is required',
+      emailRequired: 'Email is required',
+      emailFormat: 'Enter a valid email address',
+      phoneRequired: 'Phone number is required',
+      phoneFormat: 'Enter a valid phone number'
+    }
+  },
+
+  password: {
+    old: 'Current Password',
+    oldPlaceholder: 'Please enter your current password',
+    new: 'New Password',
+    newPlaceholder: 'Please enter a new password',
+    confirm: 'Confirm Password',
+    confirmPlaceholder: 'Please confirm the new password',
+    rules: {
+      oldRequired: 'Current password is required',
+      newRequired: 'New password is required',
+      length: 'Must be between 6 and 20 characters',
+      confirmRequired: 'Please confirm the password',
+      mismatch: 'The two passwords do not match'
+    }
+  },
+
+  avatar: {
+    hint: 'Click to upload an avatar',
+    upload: 'Upload',
+    submit: 'Submit',
+    dialogTitle: 'Change Avatar',
+    wrongType: 'Unsupported file type. Please upload an image, such as JPG or PNG.'
+  },
+
+  save: 'Save',
+  close: 'Close'
+}

--- a/src/lang/en-US/schedule.ts
+++ b/src/lang/en-US/schedule.ts
@@ -1,0 +1,73 @@
+export default {
+  name: 'Name',
+  namePlaceholder: 'Please enter name',
+  jobGroup: 'Task Group',
+  status: 'Status',
+  statusPlaceholder: 'Task status',
+  log: 'Log',
+
+  jobId: 'ID',
+  group: 'Group',
+  cronExpression: 'Cron Expression',
+  invokeTarget: 'Invoke Target',
+
+  // 参数 is the glossary's 'Parameter', but that entry covers the system
+  // parameter store. These are a Go function's arguments, so 'Args' -- the same
+  // word the field itself uses.
+  peekArgs: 'Args: {value}',
+  peekJobType: 'Invoke type: {value}',
+  peekMisfire: 'Misfire policy: {value}',
+  peekConcurrent: 'Concurrent: {value}',
+  none: 'None',
+
+  jobTypeApi: 'API',
+  jobTypeFunc: 'Function',
+  allow: 'Allow',
+  forbid: 'Forbid',
+
+  start: 'Start',
+  stop: 'Stop',
+  deleteTitle: 'Delete task: {name}',
+
+  addTitle: 'Add Task',
+  editTitle: 'Edit Task',
+  selectPlaceholder: 'Please select',
+  invokeTargetTip: "For example: func (t *EXEC) ExamplesNoParam(){'{'}..{'}'} -- enter ExamplesNoParam. Calling with arguments is not supported yet.",
+  args: 'Target Args',
+  argsTip: 'With arguments: enter them as a string. Without: leave it empty. Only function calls are supported for now.',
+  concurrent: 'Concurrent',
+  jobType: 'Invoke Type',
+  // 执行策略 literally reads 'execution policy', but the three options only
+  // describe what happens to a run the scheduler missed, which is what every
+  // cron library calls a misfire
+  misfirePolicy: 'Misfire Policy',
+  misfire: {
+    immediate: 'Run Immediately',
+    once: 'Run Once',
+    skip: 'Skip'
+  },
+
+  deleteConfirm: 'Delete the selected task? | Delete the {count} selected tasks?',
+  startConfirm: 'Start the task "{name}"?',
+  stopConfirm: 'Stop the task "{name}"?',
+  startSuccess: 'Started successfully',
+  stopSuccess: 'Stopped successfully',
+
+  rules: {
+    jobName: 'Name is required',
+    jobGroup: 'Task group is required',
+    invokeTarget: 'Invoke target is required',
+    cronExpression: 'Cron expression is required'
+  },
+
+  jobLog: {
+    connecting: 'Connecting',
+    open: 'Connected',
+    closed: 'Disconnected',
+    lines: '{count} line | {count} lines',
+    clear: 'Clear',
+    reconnect: 'Reconnect',
+    waiting: 'Connected, waiting for task output…',
+    disconnected: 'Not connected'
+  }
+}

--- a/src/lang/en-US/sys-tools.ts
+++ b/src/lang/en-US/sys-tools.ts
@@ -1,0 +1,25 @@
+export default {
+  monitor: {
+    system: 'System',
+    memory: 'Memory',
+    swap: 'Swap',
+    time: 'Time',
+    // The card shows a duration, not a boolean state.
+    uptime: 'Uptime',
+    disk: 'Disk',
+    hours: '{n} h',
+    download: 'Down',
+    upload: 'Up',
+    cpuFreq: 'CPU Frequency',
+    cores: 'Cores',
+    goRuntime: 'Go Runtime',
+    goVersion: 'Go Version',
+    projectDir: 'Project Path',
+    serverInfo: 'Server',
+    hostName: 'Hostname',
+    os: 'Operating System',
+    ip: 'IP Address',
+    arch: 'Architecture',
+    currentTime: 'Current Time'
+  }
+}

--- a/src/lang/zh-CN/admin/dict.ts
+++ b/src/lang/zh-CN/admin/dict.ts
@@ -1,0 +1,82 @@
+/**
+ * Both pages under src/views/admin/dict: the types list and the entries of one
+ * type. One file because the directory is one, and two sections inside it
+ * because the two pages name the same column differently -- 编号 against 编码,
+ * 字典标签 against 数据标签 -- and merging them would force one of the two
+ * spellings onto the other page.
+ *
+ * Every Chinese value is byte-for-byte what the interface renders today (PRD
+ * R5). 新增 / 修改 / 删除 / 导出 / 创建时间 / 确 定 / 取 消 come from common.ts.
+ */
+export default {
+  /** dict/index.vue -- the dictionary types. */
+  type: {
+    // ── Search and columns ────────────────────────────────────────
+    dictName: '字典名称',
+    dictNamePlaceholder: '请输入字典名称',
+    dictType: '字典类型',
+    dictTypePlaceholder: '请输入字典类型',
+    status: '状态',
+    statusPlaceholder: '字典状态',
+    dictId: '编号',
+    remark: '备注',
+
+    // ── Create / edit ─────────────────────────────────────────────
+    addTitle: '添加字典类型',
+    editTitle: '修改字典类型',
+    remarkPlaceholder: '请输入内容',
+
+    removeConfirm: '确认删除选中的 {count} 个字典类型？',
+
+    // ── Export ────────────────────────────────────────────────────
+    exportFilename: '字典类型',
+    exportHeader: {
+      dictId: '编号',
+      dictName: '字典名称',
+      dictType: '字典类型',
+      status: '状态',
+      remark: '备注'
+    },
+
+    rules: {
+      dictName: '字典名称不能为空',
+      dictType: '字典类型不能为空'
+    }
+  },
+
+  /** dict/data.vue -- the entries of one dictionary. */
+  data: {
+    // ── Search and columns ────────────────────────────────────────
+    // The search bar labels the type picker 字典名称 while the form labels the
+    // same field 字典类型: the picker shows names, the form shows the type
+    // string. Both are kept.
+    dictName: '字典名称',
+    dictLabel: '字典标签',
+    dictLabelPlaceholder: '请输入字典标签',
+    status: '状态',
+    statusPlaceholder: '数据状态',
+    dictCode: '编码',
+    dictValue: '字典键值',
+    dictSort: '排序',
+    remark: '备注',
+
+    // ── Create / edit ─────────────────────────────────────────────
+    addTitle: '添加字典数据',
+    editTitle: '修改字典数据',
+    dictType: '字典类型',
+    label: '数据标签',
+    labelPlaceholder: '请输入数据标签',
+    value: '数据键值',
+    valuePlaceholder: '请输入数据键值',
+    displaySort: '显示排序',
+    remarkPlaceholder: '请输入内容',
+
+    removeConfirm: '确认删除选中的 {count} 条字典数据？',
+
+    rules: {
+      dictLabel: '数据标签不能为空',
+      dictValue: '数据键值不能为空',
+      dictSort: '显示排序不能为空'
+    }
+  }
+}

--- a/src/lang/zh-CN/admin/index.ts
+++ b/src/lang/zh-CN/admin/index.ts
@@ -3,16 +3,35 @@ import sysRole from './sys-role'
 import sysMenu from './sys-menu'
 import sysConfig from './sys-config'
 import sysDept from './sys-dept'
+import sysPost from './sys-post'
+import dict from './dict'
+import sysApi from './sys-api'
+import sysOperLog from './sys-oper-log'
+import sysLoginLog from './sys-login-log'
 
 /**
  * The admin section, one module per page under src/views/admin.
  *
  * The file names match those directories -- sys-user.ts for sys-user/ -- so
  * where a page's text lives needs no decision. The keys are camelCase because
- * they are read as `t('admin.sysUser.addTitle')`.
+ * they are read as `t('admin.sysUser.addTitle')`. A directory holding two pages
+ * still gets one file: sys-config.ts carries the list page at its top level and
+ * the settings form under `set`, dict.ts carries the types under `type` and the
+ * entries under `data`.
  *
- * Only the five pages migrated so far are here. The rest of src/views/admin
- * still holds its Chinese in the template, and a half-migrated page would be
- * worse than an unmigrated one, so they are left whole until their batch.
+ * The pages still holding their Chinese in the template -- the generator, the
+ * scheduler, the monitor -- are left whole until their batch, because a
+ * half-migrated page is worse than an unmigrated one.
  */
-export default { sysUser, sysRole, sysMenu, sysConfig, sysDept }
+export default {
+  sysUser,
+  sysRole,
+  sysMenu,
+  sysConfig,
+  sysDept,
+  sysPost,
+  dict,
+  sysApi,
+  sysOperLog,
+  sysLoginLog
+}

--- a/src/lang/zh-CN/admin/sys-api.ts
+++ b/src/lang/zh-CN/admin/sys-api.ts
@@ -1,0 +1,40 @@
+/**
+ * The API page: the routes the Go side registers, which this page can only
+ * retitle.
+ *
+ * Every Chinese value is byte-for-byte what the interface renders today (PRD
+ * R5). Handle and Method stay English in both packs -- they are English on the
+ * Chinese screen too, and are the names of the fields themselves.
+ *
+ * 修改 / 创建时间 / 确 定 / 取 消 come from common.ts.
+ */
+export default {
+  // ── Search ──────────────────────────────────────────────────────
+  title: '标题',
+  titlePlaceholder: '请输入标题',
+  path: '地址',
+  pathPlaceholder: '请输入地址',
+  selectPlaceholder: '请选择',
+  type: '类型',
+
+  // ── Columns ─────────────────────────────────────────────────────
+  api: '接口',
+  /** Tag shown in place of a title the backend never gave this route. */
+  none: '暂无',
+  /** The path column's hover card, where the rest of the record is readable. */
+  peekHandle: 'Handle：{value}',
+  peekType: '类型：{value}',
+  peekTitle: '标题：{value}',
+
+  // ── Edit ────────────────────────────────────────────────────────
+  addTitle: '添加接口',
+  editTitle: '修改接口',
+  typePlaceholder: '请选择类型',
+  actionPlaceholder: '请选择方式',
+
+  rules: {
+    handle: 'handle 不能为空',
+    title: '标题不能为空',
+    type: '类型不能为空'
+  }
+}

--- a/src/lang/zh-CN/admin/sys-config.ts
+++ b/src/lang/zh-CN/admin/sys-config.ts
@@ -54,5 +54,60 @@ export default {
     configKey: '参数键名不能为空',
     configValue: '参数键值不能为空',
     isFrontend: '是否前台显示不能为空'
+  },
+
+  /**
+   * sys-config/set.vue -- the settings form, the other page in this directory.
+   *
+   * Its own section rather than more keys at the top level: this page names the
+   * settings it edits (系统名称, 用户初始密码), while the list page above names
+   * the columns of the table they are stored in (参数名称, 参数键值), and the
+   * two vocabularies would collide if merged.
+   */
+  set: {
+    // ── Sidebar ───────────────────────────────────────────────────
+    sidebarTitle: '系统配置',
+    sidebarSub: '基础信息与外观设置',
+    basic: '基础信息',
+    basicSub: '名称、Logo、密码',
+    appearance: '外观设置',
+    appearanceSub: '皮肤与主题风格',
+
+    // ── Basic information ─────────────────────────────────────────
+    basicTitle: '系统基础信息',
+    basicDesc: '配置系统名称、Logo 及用户默认密码',
+    logoEmpty: '暂无 Logo',
+    logoName: '系统 Logo',
+    logoHint: '推荐 200×200，支持 JPG / PNG，大小不超过 2MB',
+    upload: '上传图片',
+    appName: '系统名称',
+    appNamePlaceholder: '请输入系统名称',
+    initPassword: '用户初始密码',
+    initPasswordPlaceholder: '请输入初始密码',
+
+    // ── Appearance ────────────────────────────────────────────────
+    appearanceDesc: '调整皮肤样式与侧栏主题风格',
+    skin: '皮肤样式',
+    skinPlaceholder: '请选择皮肤样式',
+    skinBlue: '蓝色',
+    sideTheme: '侧栏主题',
+    sideThemePlaceholder: '请选择侧栏主题',
+    themeHint: '点击快速切换主题',
+    themeDark: '深色主题',
+    themeLight: '浅色主题',
+
+    // ── Saving ────────────────────────────────────────────────────
+    save: '保存设置',
+    /**
+     * Only reached when the server answers without a message of its own -- the
+     * page still prefers `response.msg`, which is what it shows today.
+     */
+    saveOk: '保存成功',
+    logoTooLarge: '文件大小超过 2MB',
+
+    rules: {
+      appName: '请输入系统名称',
+      initPassword: '请输入初始密码'
+    }
   }
 }

--- a/src/lang/zh-CN/admin/sys-login-log.ts
+++ b/src/lang/zh-CN/admin/sys-login-log.ts
@@ -1,0 +1,27 @@
+/**
+ * The login log: read and delete, nothing writes it.
+ *
+ * Every Chinese value is byte-for-byte what the interface renders today (PRD
+ * R5), 'ip 地址' and its lower-case i included -- the column, the search label
+ * and the placeholder all spell it that way today. 删除 comes from common.ts.
+ */
+export default {
+  // ── Search ──────────────────────────────────────────────────────
+  username: '用户名',
+  usernamePlaceholder: '请输入用户名',
+  status: '状态',
+  statusPlaceholder: '登录状态',
+  ipaddr: 'ip 地址',
+  ipaddrPlaceholder: '请输入 ip 地址',
+
+  // ── Columns ─────────────────────────────────────────────────────
+  msg: '类型',
+  /** The address column's hover card, which is where the client details are. */
+  peekLocation: '归属地：{value}',
+  peekBrowser: '浏览器：{value}',
+  peekOs: '系统：{value}',
+  peekPlatform: '固件：{value}',
+  loginTime: '登录时间',
+
+  removeConfirm: '确认删除选中的 {count} 条登录日志？'
+}

--- a/src/lang/zh-CN/admin/sys-oper-log.ts
+++ b/src/lang/zh-CN/admin/sys-oper-log.ts
@@ -1,0 +1,67 @@
+/**
+ * The operation log: an audit trail, so it reads, deletes and empties, and
+ * nothing on it creates a record.
+ *
+ * Every Chinese value is byte-for-byte what the interface renders today (PRD
+ * R5). 删除 / 导出 / 提示 / 确定 / 取消 come from common.ts; the detail
+ * dialog's 关 闭 does not, because common.close is 关闭 without the spacing a
+ * two-character Chinese button gets, and this is the only button in the
+ * application that spells it the other way.
+ */
+export default {
+  // ── Search ──────────────────────────────────────────────────────
+  operUrl: '访问地址',
+  operUrlPlaceholder: '请输入访问地址',
+  status: '状态',
+  statusPlaceholder: '操作状态',
+  operTime: '操作时间',
+  rangeSeparator: '至',
+  startDate: '开始日期',
+  endDate: '结束日期',
+
+  // ── Toolbar ─────────────────────────────────────────────────────
+  clean: '清空',
+
+  // ── Columns ─────────────────────────────────────────────────────
+  operId: '编号',
+  request: '请求',
+  /** The request column's hover card, which is where the rest of the row is. */
+  peekHost: 'Host：{value}',
+  peekLocation: '归属地：{value}',
+  peekLatency: '耗时：{value}',
+  operName: '操作人员',
+  operDate: '操作日期',
+  detail: '详细',
+
+  // ── Detail dialog ───────────────────────────────────────────────
+  detailTitle: '操作日志详细',
+  detailUrl: '请求地址',
+  loginInfo: '登录信息',
+  requestMethod: '请求方式',
+  latency: '耗时',
+  module: '系统模块',
+  operStatus: '操作状态',
+  operParam: '请求参数',
+  jsonResult: '返回参数',
+  dialogClose: '关 闭',
+
+  // ── Deleting and emptying ───────────────────────────────────────
+  removeConfirm: '确认删除选中的 {count} 条操作日志？',
+  cleanConfirm: '确认清空全部操作日志？此操作不可撤销。',
+  cleanOk: '已清空',
+
+  // ── Export ──────────────────────────────────────────────────────
+  exportFilename: '操作日志',
+  exportHeader: {
+    operId: '编号',
+    module: '系统模块',
+    businessType: '操作类型',
+    operName: '操作人员',
+    operIp: '主机',
+    operLocation: '操作地点',
+    requestMethod: '请求方式',
+    operUrl: '请求地址',
+    status: '状态',
+    operDate: '操作日期'
+  }
+}

--- a/src/lang/zh-CN/admin/sys-post.ts
+++ b/src/lang/zh-CN/admin/sys-post.ts
@@ -1,0 +1,53 @@
+/**
+ * The position page.
+ *
+ * Every Chinese value is byte-for-byte what the interface renders today (PRD
+ * R5). The page carries three spellings of the same idea -- 岗位排序 in the
+ * column, 岗位顺序 on the form, 排序 in the exported sheet -- and all three are
+ * kept, because the assertions in tests/e2e/mocked/sys-post.spec.ts read the
+ * interface as it is today.
+ *
+ * 新增 / 修改 / 删除 / 导出 / 创建时间 / 确 定 / 取 消 come from common.ts.
+ */
+export default {
+  // ── Search ──────────────────────────────────────────────────────
+  postCode: '岗位编码',
+  postCodePlaceholder: '请输入岗位编码',
+  postName: '岗位名称',
+  postNamePlaceholder: '请输入岗位名称',
+  status: '状态',
+  statusPlaceholder: '岗位状态',
+
+  // ── Columns ─────────────────────────────────────────────────────
+  postId: '岗位编号',
+  postSort: '岗位排序',
+
+  // ── Create / edit ───────────────────────────────────────────────
+  addTitle: '添加岗位',
+  editTitle: '修改岗位',
+  /**
+   * The form's placeholder under 岗位编码, worded differently from the search
+   * bar's 请输入岗位编码. Both spellings are kept rather than merged.
+   */
+  codeNamePlaceholder: '请输入编码名称',
+  sort: '岗位顺序',
+  postStatus: '岗位状态',
+  remark: '备注',
+  remarkPlaceholder: '请输入内容',
+
+  // ── Export ──────────────────────────────────────────────────────
+  exportFilename: '岗位管理',
+  exportHeader: {
+    postId: '岗位编号',
+    postCode: '岗位编码',
+    postName: '岗位名称',
+    sort: '排序',
+    createdAt: '创建时间'
+  },
+
+  rules: {
+    postName: '岗位名称不能为空',
+    postCode: '岗位编码不能为空',
+    sort: '岗位顺序不能为空'
+  }
+}

--- a/src/lang/zh-CN/demo.ts
+++ b/src/lang/zh-CN/demo.ts
@@ -1,0 +1,25 @@
+/**
+ * The reference list page, which AGENTS.md points newcomers at.
+ *
+ * Its status labels are literals rather than a dictionary lookup, unlike every
+ * real page -- `row.status === '1' ? '正常' : '停用'`. Migrated as they are
+ * (PRD R5); turning them into a useDict call is a change to what the example
+ * teaches and belongs in its own commit.
+ */
+export default {
+  name: '名称',
+  namePlaceholder: '请输入名称',
+  code: '编码',
+  codePlaceholder: '请输入编码',
+  price: '单价',
+  status: '状态',
+  statusPlaceholder: '请选择状态',
+  normal: '正常',
+  disabled: '停用',
+  remark: '备注',
+  remarkPlaceholder: '请输入内容',
+  rules: {
+    name: '名称不能为空',
+    code: '编码不能为空'
+  }
+}

--- a/src/lang/zh-CN/dev-tools/basic-info-form.ts
+++ b/src/lang/zh-CN/dev-tools/basic-info-form.ts
@@ -1,0 +1,40 @@
+/**
+ * The 基本信息 tab -- views/dev-tools/gen/basicInfoForm.vue.
+ *
+ * Every Chinese value is byte-for-byte what the interface renders today (PRD
+ * R5). `rules` repeats two of the placeholders word for word; they are kept as
+ * separate keys because a placeholder and a validation message are different
+ * roles, and one being reworded should not silently reword the other.
+ *
+ * The commented-out 是否逻辑删除 block in the template is deliberately not here:
+ * it renders nothing, and translating dead markup invites someone to uncomment
+ * it later and find half a form.
+ */
+export default {
+  tableName: '数据表名称',
+  tableNameTip: '数据库表名称，针对gorm对应的table()使用，⚠️这里必须是蛇形结构',
+  tableNamePlaceholder: '请输入表名称',
+
+  tableComment: '菜单名称',
+  tableCommentTip: '同步的数据库表名称，生成配置数据时，用作菜单名称',
+  tableCommentPlaceholder: '请输入菜单名称',
+
+  className: '结构体模型名称',
+  classNameTip: '结构体模型名称，代码中的struct名称定义使用',
+  classNamePlaceholder: '请输入',
+
+  functionAuthor: '作者名称',
+  functionAuthorPlaceholder: '请输入作者名称',
+
+  remark: '备注',
+
+  rules: {
+    tableName: '请输入表名称',
+    tableNamePattern: '只允许小写字母，例如 sys_demo',
+    tableComment: '请输入菜单名称',
+    className: '请输入模型名称',
+    classNamePattern: '必须以大写字母开头，例如 SysDemo',
+    functionAuthor: '请输入作者',
+    functionAuthorPattern: '只允许字母 a-z 或 A-Z'
+  }
+}

--- a/src/lang/zh-CN/dev-tools/edit-table.ts
+++ b/src/lang/zh-CN/dev-tools/edit-table.ts
@@ -1,0 +1,55 @@
+/**
+ * The generated-table editor -- views/dev-tools/gen/editTable.vue.
+ *
+ * The 字段信息 tab is a developer's table: its headers name Go and SQL
+ * artefacts rather than business concepts, so the English side uses the words a
+ * developer already knows (Go Type, JSON Field) instead of a literal rendering.
+ *
+ * Every Chinese value is byte-for-byte what the interface renders today (PRD R5).
+ */
+export default {
+  // ── Tabs ────────────────────────────────────────────────────────
+  tabBasic: '基本信息',
+  tabColumns: '字段信息',
+  tabGen: '生成信息',
+
+  hiddenColumns: '⚠️表字段中的id、create_by、update_by、created_at、updated_at、deleted_at的字段在此列表中已经隐藏',
+
+  // ── Column table ────────────────────────────────────────────────
+  // type="index", so this 序号 is the row ordinal -- gen.tableId is the key
+  index: '序号',
+  columnName: '字段列名',
+  columnComment: '字段描述',
+  columnType: '物理类型',
+  goType: 'go类型',
+  goField: 'go属性',
+  jsonField: 'json属性',
+
+  isInsert: '编辑',
+  isList: '列表',
+  isListTip: '是否在列表中展示，打勾表示展示',
+  isQuery: '查询',
+  isQueryTip: '是否作为搜索条件，打勾表示作为条件',
+  queryType: '查询方式',
+  isRequired: '必填',
+
+  htmlType: '显示类型',
+  htmlTypes: {
+    input: '文本框',
+    select: '下拉框',
+    radio: '单选框',
+    textarea: '文本域'
+  },
+
+  dictType: '字典类型',
+  fkTableName: '关系表',
+  fkLabelId: '关系表key',
+  fkLabelName: '关系表value',
+  selectPlaceholder: '请选择',
+
+  // ── Footer ──────────────────────────────────────────────────────
+  back: '返回',
+  submit: '提交',
+  validationFailed: '表单校验未通过，请重新检查提交内容',
+  saveSuccess: '保存成功'
+}

--- a/src/lang/zh-CN/dev-tools/gen-info-form.ts
+++ b/src/lang/zh-CN/dev-tools/gen-info-form.ts
@@ -1,0 +1,49 @@
+/**
+ * The 生成信息 tab -- views/dev-tools/gen/genInfoForm.vue.
+ *
+ * Every Chinese value is byte-for-byte what the interface renders today (PRD
+ * R5), including the mismatch in `rules`: the fields are labelled 应用名 and
+ * 接口路径 while their validation messages say 生成包路径 and 生成模块名. That
+ * is what the page says today and it is copied rather than corrected.
+ *
+ * moduleNameTip carries a literal `{sys-user}`. Braces are vue-i18n's
+ * interpolation syntax, so it is written with the literal-interpolation form
+ * `{'{'}` -- plain braces would be parsed as a placeholder named `sys-user`.
+ */
+export default {
+  tplCategory: '生成模板',
+  tplCrud: '关系表（增删改查）',
+
+  packageName: '应用名',
+  packageNameTip: '应用名，例如：在app文件夹下将该功能发到那个应用中，默认：admin',
+
+  businessName: '业务名',
+  businessNameTip: '可理解为功能英文名，例如 user',
+
+  functionName: '功能描述',
+  functionNameTip: '同步的数据库表备注，用作类描述，例如：用户',
+
+  moduleName: '接口路径',
+  moduleNameTip: "接口路径，例如：api/v1/{'{'}sys-user{'}'}",
+
+  // ── The tree section, shown only for tplCategory 'tree' ──────────
+  otherInfo: '其他信息',
+  treeCode: '树编码字段',
+  treeCodeTip: '树显示的编码字段名， 如：dept_id',
+  treeParentCode: '树父编码字段',
+  treeParentCodeTip: '树显示的父编码字段名， 如：parent_Id',
+  treeName: '树名称字段',
+  treeNameTip: '树节点的显示名称字段名， 如：dept_name',
+  selectPlaceholder: '请选择',
+
+  rules: {
+    tplCategory: '请选择生成模板',
+    packageName: '请输入生成包路径',
+    packageNamePattern: '只允许小写字母，例如 system',
+    moduleName: '请输入生成模块名',
+    moduleNamePattern: '只允许小写字母，例如 sys-demo',
+    businessName: '请输入生成业务名',
+    businessNamePattern: '字母开头，只允许 a-z 与 A-Z',
+    functionName: '请输入生成功能名'
+  }
+}

--- a/src/lang/zh-CN/dev-tools/gen.ts
+++ b/src/lang/zh-CN/dev-tools/gen.ts
@@ -1,0 +1,40 @@
+/**
+ * The code generator's table list -- views/dev-tools/gen/index.vue.
+ *
+ * Every Chinese value is byte-for-byte what the interface renders today (PRD
+ * R5). Two spellings that look like duplicates and are not: this page's 编辑
+ * button says 编辑 while every other list page says 修改 (common.edit), and its
+ * 表名称 is the plain table name while basicInfoForm's is 数据表名称. Both are
+ * kept as they are; unifying the Chinese is a separate change.
+ */
+export default {
+  // ── Search ──────────────────────────────────────────────────────
+  tableName: '表名称',
+  tableNamePlaceholder: '请输入表名称',
+  tableComment: '菜单名称',
+  tableCommentPlaceholder: '请输入菜单名称',
+
+  // ── Toolbar ─────────────────────────────────────────────────────
+  import: '导入',
+
+  // ── Columns ─────────────────────────────────────────────────────
+  // Bound to tableId, so this 序号 is a primary key -- editTable's 序号 is a
+  // row ordinal and translates differently.
+  tableId: '序号',
+  className: '模型名称',
+
+  // ── Row actions ─────────────────────────────────────────────────
+  edit: '编辑',
+  preview: '预览',
+  moreActions: '更多操作',
+  generateToProject: '生成到项目',
+  generateConfig: '生成配置',
+  generateMigration: '生成迁移脚本',
+
+  // ── Preview dialog ──────────────────────────────────────────────
+  previewTitle: '代码预览',
+
+  // Passed to useRemove's confirmText, which is called when the dialog opens
+  deleteConfirm: '确认删除选中的 {count} 张表的生成配置？',
+  generated: '已生成'
+}

--- a/src/lang/zh-CN/dev-tools/index.ts
+++ b/src/lang/zh-CN/dev-tools/index.ts
@@ -1,0 +1,22 @@
+import gen from './gen'
+import editTable from './edit-table'
+import basicInfoForm from './basic-info-form'
+import genInfoForm from './gen-info-form'
+
+/**
+ * The dev-tools section, one module per page under src/views/dev-tools.
+ *
+ * The file names match the components they belong to -- gen.ts for gen/index.vue
+ * (`defineOptions({ name: 'Gen' })`), edit-table.ts for editTable.vue -- so the
+ * keys read as `devTools.editTable.tabBasic`. The generator's editor is three
+ * files rather than one because its two tabs are separate components with
+ * separate rule sets; keeping their text together would make the biggest
+ * language file in the repository out of the least-visited page.
+ *
+ * swagger/index.vue is absent and needs nothing: it is an iframe around the
+ * backend's own Swagger UI and contains no Chinese at all.
+ *
+ * build/index.vue is absent for the opposite reason -- it is not migrated yet,
+ * and a half-migrated page is worse than an unmigrated one.
+ */
+export default { gen, editTable, basicInfoForm, genInfoForm }

--- a/src/lang/zh-CN/index.ts
+++ b/src/lang/zh-CN/index.ts
@@ -1,5 +1,8 @@
 import common from './common'
 import layout from './layout'
+import profile from './profile'
+import sysTools from './sys-tools'
+import demo from './demo'
 import route from './route'
 import components from './components'
 import login from './login'
@@ -16,4 +19,4 @@ import composables from './composables'
  * drift the first time someone renamed a menu. Chinese always falls through to
  * the database value; see lang/backend.ts.
  */
-export default { common, layout, route, components, login, dashboard, admin, composables }
+export default { common, demo, sysTools, profile, layout, route, components, login, dashboard, admin, composables }

--- a/src/lang/zh-CN/index.ts
+++ b/src/lang/zh-CN/index.ts
@@ -3,6 +3,8 @@ import layout from './layout'
 import profile from './profile'
 import sysTools from './sys-tools'
 import demo from './demo'
+import devTools from './dev-tools'
+import schedule from './schedule'
 import route from './route'
 import components from './components'
 import login from './login'
@@ -19,4 +21,4 @@ import composables from './composables'
  * drift the first time someone renamed a menu. Chinese always falls through to
  * the database value; see lang/backend.ts.
  */
-export default { common, demo, sysTools, profile, layout, route, components, login, dashboard, admin, composables }
+export default { common, schedule, devTools, demo, sysTools, profile, layout, route, components, login, dashboard, admin, composables }

--- a/src/lang/zh-CN/profile.ts
+++ b/src/lang/zh-CN/profile.ts
@@ -1,0 +1,68 @@
+/**
+ * The account pages: the summary card, the two tabs, and the avatar cropper.
+ *
+ * Every Chinese value is byte-for-byte what the interface renders today (PRD
+ * R5), including `'请输入正确的邮箱地址` -- that leading apostrophe is in the
+ * source and reaches the screen. Fixing it is a separate change; correcting it
+ * here would make the e2e assertions that guard this migration fail for the
+ * wrong reason.
+ */
+export default {
+  title: '个人信息',
+  username: '用户名称',
+  phone: '手机号码',
+  email: '用户邮箱',
+  dept: '所属部门',
+  role: '所属角色',
+  createdAt: '创建日期',
+  noRole: '暂无',
+
+  basic: '基本资料',
+  tabs: {
+    info: '基本资料',
+    password: '修改密码'
+  },
+
+  info: {
+    nickName: '用户昵称',
+    phone: '手机号码',
+    email: '邮箱',
+    sex: '性别',
+    male: '男',
+    female: '女',
+    rules: {
+      nickName: '用户昵称不能为空',
+      emailRequired: '邮箱地址不能为空',
+      emailFormat: "'请输入正确的邮箱地址",
+      phoneRequired: '手机号码不能为空',
+      phoneFormat: '请输入正确的手机号码'
+    }
+  },
+
+  password: {
+    old: '旧密码',
+    oldPlaceholder: '请输入旧密码',
+    new: '新密码',
+    newPlaceholder: '请输入新密码',
+    confirm: '确认密码',
+    confirmPlaceholder: '请确认密码',
+    rules: {
+      oldRequired: '旧密码不能为空',
+      newRequired: '新密码不能为空',
+      length: '长度在 6 到 20 个字符',
+      confirmRequired: '确认密码不能为空',
+      mismatch: '两次输入的密码不一致'
+    }
+  },
+
+  avatar: {
+    hint: '点击上传头像',
+    upload: '上传',
+    submit: '提 交',
+    dialogTitle: '修改头像',
+    wrongType: '文件格式错误，请上传图片类型,如：JPG，PNG后缀的文件。'
+  },
+
+  save: '保存',
+  close: '关闭'
+}

--- a/src/lang/zh-CN/schedule.ts
+++ b/src/lang/zh-CN/schedule.ts
@@ -1,0 +1,91 @@
+/**
+ * Scheduled tasks -- views/schedule/index.vue and views/schedule/log.vue.
+ *
+ * One file for two pages, unlike admin/ and dev-tools/: the log page owns eight
+ * strings and exists only as the destination of this one's 日志 button. It sits
+ * under `jobLog` so the toolbar button can keep the plain `log` key.
+ *
+ * Every Chinese value is byte-for-byte what the interface renders today (PRD
+ * R5). Two starts and two stops rather than one string with a {verb}: the page
+ * built its confirmation as `确认${verb}任务「${name}」？`, which reads as one
+ * sentence in Chinese and as a broken one in any language that does not put the
+ * verb there.
+ *
+ * invokeTargetTip carries a literal `{..}` from a Go function body. Braces are
+ * vue-i18n's interpolation syntax, so it is written with the
+ * literal-interpolation form `{'{'}`.
+ */
+export default {
+  // ── Search ──────────────────────────────────────────────────────
+  name: '名称',
+  namePlaceholder: '请输入名称',
+  jobGroup: '任务分组',
+  status: '状态',
+  statusPlaceholder: '任务状态',
+  log: '日志',
+
+  // ── Columns ─────────────────────────────────────────────────────
+  jobId: '编码',
+  group: '分组',
+  cronExpression: 'cron 表达式',
+  invokeTarget: '调用目标',
+
+  /** The invoke-target column's hover card. */
+  peekArgs: '参数：{value}',
+  peekJobType: '调用类型：{value}',
+  peekMisfire: '执行策略：{value}',
+  peekConcurrent: '并发：{value}',
+  none: '无',
+
+  jobTypeApi: '接口',
+  jobTypeFunc: '函数',
+  allow: '允许',
+  forbid: '禁止',
+
+  // ── Row actions ─────────────────────────────────────────────────
+  start: '启动',
+  stop: '停止',
+  deleteTitle: '删除任务：{name}',
+
+  // ── Create / edit ───────────────────────────────────────────────
+  addTitle: '添加任务',
+  editTitle: '修改任务',
+  selectPlaceholder: '请选择',
+  invokeTargetTip: "调用示例：func (t *EXEC) ExamplesNoParam(){'{'}..{'}'} 填写 ExamplesNoParam 即可；目前不支持带参调用",
+  args: '目标参数',
+  argsTip: '有参：请以 string 格式填写；无参：留空。目前仅支持函数调用',
+  concurrent: '是否并发',
+  jobType: '调用类型',
+  misfirePolicy: '执行策略',
+  misfire: {
+    immediate: '立即执行',
+    once: '执行一次',
+    skip: '放弃执行'
+  },
+
+  // ── Confirmations ───────────────────────────────────────────────
+  deleteConfirm: '确认删除选中的 {count} 个任务？',
+  startConfirm: '确认启动任务「{name}」？',
+  stopConfirm: '确认停止任务「{name}」？',
+  startSuccess: '启动成功',
+  stopSuccess: '停止成功',
+
+  rules: {
+    jobName: '名称不能为空',
+    jobGroup: '任务分组不能为空',
+    invokeTarget: '调用目标不能为空',
+    cronExpression: 'cron 表达式不能为空'
+  },
+
+  // ── The live log page ───────────────────────────────────────────
+  jobLog: {
+    connecting: '连接中',
+    open: '已连接',
+    closed: '已断开',
+    lines: '{count} 行',
+    clear: '清空',
+    reconnect: '重连',
+    waiting: '已连接，等待任务输出…',
+    disconnected: '未连接'
+  }
+}

--- a/src/lang/zh-CN/sys-tools.ts
+++ b/src/lang/zh-CN/sys-tools.ts
@@ -1,0 +1,25 @@
+/** The server monitor. Labels only -- every value comes from the API. */
+export default {
+  monitor: {
+    system: '系统',
+    memory: '内存',
+    swap: '交换',
+    time: '时间',
+    uptime: '在线',
+    disk: '硬盘',
+    hours: '{n}小时',
+    download: '下载',
+    upload: '上传',
+    cpuFreq: 'CPU主频',
+    cores: '核心数',
+    goRuntime: 'go运行环境',
+    goVersion: 'GO 版本',
+    projectDir: '项目地址',
+    serverInfo: '服务器信息',
+    hostName: '主机名称',
+    os: '操作系统',
+    ip: '服务器IP',
+    arch: '系统架构',
+    currentTime: '当前时间'
+  }
+}

--- a/src/views/admin/dict/data.vue
+++ b/src/views/admin/dict/data.vue
@@ -2,7 +2,7 @@
   <PageContainer>
     <ProTable :table="table" selection row-key="dictCode" :actions-width="120">
       <template #search>
-        <el-form-item label="字典名称">
+        <el-form-item :label="$t('admin.dict.data.dictName')">
           <el-select v-model="table.query.dictType" style="width: 180px">
             <el-option
               v-for="item in typeOptions"
@@ -12,11 +12,21 @@
             />
           </el-select>
         </el-form-item>
-        <el-form-item label="字典标签">
-          <el-input v-model="table.query.dictLabel" placeholder="请输入字典标签" clearable style="width: 160px" />
+        <el-form-item :label="$t('admin.dict.data.dictLabel')">
+          <el-input
+            v-model="table.query.dictLabel"
+            :placeholder="$t('admin.dict.data.dictLabelPlaceholder')"
+            clearable
+            style="width: 160px"
+          />
         </el-form-item>
-        <el-form-item label="状态">
-          <el-select v-model="table.query.status" placeholder="数据状态" clearable style="width: 130px">
+        <el-form-item :label="$t('admin.dict.data.status')">
+          <el-select
+            v-model="table.query.status"
+            :placeholder="$t('admin.dict.data.statusPlaceholder')"
+            clearable
+            style="width: 130px"
+          >
             <el-option
               v-for="item in sys_normal_disable"
               :key="item.value"
@@ -28,78 +38,106 @@
       </template>
 
       <template #toolbar>
-        <el-button v-permisaction="['admin:sysDictData:add']" type="primary" @click="handleAdd">新增</el-button>
+        <el-button v-permisaction="['admin:sysDictData:add']" type="primary" @click="handleAdd">
+          {{ $t('common.add') }}
+        </el-button>
         <el-button
           v-permisaction="['admin:sysDictData:remove']"
           type="danger"
           plain
           :disabled="table.multiple"
           @click="remove(table.selectedIds)"
-        >删除</el-button>
+        >{{ $t('common.delete') }}</el-button>
       </template>
 
-      <el-table-column label="编码" prop="dictCode" width="80" />
-      <el-table-column label="字典标签" prop="dictLabel" min-width="140" show-overflow-tooltip />
-      <el-table-column label="字典键值" prop="dictValue" min-width="140" show-overflow-tooltip />
-      <el-table-column label="排序" prop="dictSort" width="80" />
-      <el-table-column label="状态" prop="status" width="90">
+      <el-table-column :label="$t('admin.dict.data.dictCode')" prop="dictCode" width="80" />
+      <el-table-column
+        :label="$t('admin.dict.data.dictLabel')"
+        prop="dictLabel"
+        min-width="140"
+        show-overflow-tooltip
+      />
+      <el-table-column
+        :label="$t('admin.dict.data.dictValue')"
+        prop="dictValue"
+        min-width="140"
+        show-overflow-tooltip
+      />
+      <el-table-column :label="$t('admin.dict.data.dictSort')" prop="dictSort" width="80" />
+      <el-table-column :label="$t('admin.dict.data.status')" prop="status" width="90">
         <template #default="{ row }">
           <el-tag :type="Number(row.status) === 2 ? 'success' : 'danger'" disable-transitions>
             {{ dictLabel(sys_normal_disable, row.status) }}
           </el-tag>
         </template>
       </el-table-column>
-      <el-table-column label="备注" prop="remark" min-width="160" show-overflow-tooltip />
-      <el-table-column label="创建时间" prop="createdAt" min-width="110">
+      <el-table-column
+        :label="$t('admin.dict.data.remark')"
+        prop="remark"
+        min-width="160"
+        show-overflow-tooltip
+      />
+      <el-table-column :label="$t('common.createdAt')" prop="createdAt" min-width="110">
         <template #default="{ row }"><DateCell :value="row.createdAt" /></template>
       </el-table-column>
 
       <template #actions="{ row }">
         <el-button v-permisaction="['admin:sysDictData:edit']" link type="primary" @click="form.openEdit(row)">
-          修改
+          {{ $t('common.edit') }}
         </el-button>
         <el-button v-permisaction="['admin:sysDictData:remove']" link type="danger" @click="remove(row.dictCode)">
-          删除
+          {{ $t('common.delete') }}
         </el-button>
       </template>
     </ProTable>
 
     <el-dialog v-model="form.visible" :title="form.title" width="500px" :close-on-click-modal="false">
       <el-form :ref="form.bindFormRef" :model="form.model" :rules="form.rules" label-width="90px">
-        <el-form-item label="字典类型">
+        <el-form-item :label="$t('admin.dict.data.dictType')">
           <el-input v-model="form.model.dictType" disabled />
         </el-form-item>
-        <el-form-item label="数据标签" prop="dictLabel">
-          <el-input v-model="form.model.dictLabel" placeholder="请输入数据标签" />
+        <el-form-item :label="$t('admin.dict.data.label')" prop="dictLabel">
+          <el-input v-model="form.model.dictLabel" :placeholder="$t('admin.dict.data.labelPlaceholder')" />
         </el-form-item>
-        <el-form-item label="数据键值" prop="dictValue">
-          <el-input v-model="form.model.dictValue" placeholder="请输入数据键值" :disabled="form.isEdit" />
+        <el-form-item :label="$t('admin.dict.data.value')" prop="dictValue">
+          <el-input
+            v-model="form.model.dictValue"
+            :placeholder="$t('admin.dict.data.valuePlaceholder')"
+            :disabled="form.isEdit"
+          />
         </el-form-item>
-        <el-form-item label="显示排序" prop="dictSort">
+        <el-form-item :label="$t('admin.dict.data.displaySort')" prop="dictSort">
           <el-input-number v-model="form.model.dictSort" controls-position="right" :min="0" />
         </el-form-item>
-        <el-form-item label="状态" prop="status">
+        <el-form-item :label="$t('admin.dict.data.status')" prop="status">
           <el-radio-group v-model="form.model.status">
             <el-radio v-for="item in sys_normal_disable" :key="item.value" :value="item.value">
               {{ item.label }}
             </el-radio>
           </el-radio-group>
         </el-form-item>
-        <el-form-item label="备注" prop="remark">
-          <el-input v-model="form.model.remark" type="textarea" placeholder="请输入内容" />
+        <el-form-item :label="$t('admin.dict.data.remark')" prop="remark">
+          <el-input
+            v-model="form.model.remark"
+            type="textarea"
+            :placeholder="$t('admin.dict.data.remarkPlaceholder')"
+          />
         </el-form-item>
       </el-form>
       <template #footer>
-        <el-button @click="form.close()">取 消</el-button>
-        <el-button type="primary" :loading="form.submitting" @click="form.submit()">确 定</el-button>
+        <el-button @click="form.close()">{{ $t('common.dialogCancel') }}</el-button>
+        <el-button type="primary" :loading="form.submitting" @click="form.submit()">
+          {{ $t('common.dialogConfirm') }}
+        </el-button>
       </template>
     </el-dialog>
   </PageContainer>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import type { FormRules } from 'element-plus'
 
 import PageContainer from '@/components/PageContainer/index.vue'
@@ -115,6 +153,7 @@ import type { SysDictData, SysDictDataQuery, SysDictType } from '@/types/admin'
 defineOptions({ name: 'SysDictDataManage' })
 
 const route = useRoute()
+const { t } = useI18n()
 const { sys_normal_disable } = useDict('sys_normal_disable')
 
 /**
@@ -161,11 +200,19 @@ onMounted(async() => {
   await options
 })
 
-const rules: FormRules = {
-  dictLabel: [{ required: true, message: '数据标签不能为空', trigger: 'blur' }],
-  dictValue: [{ required: true, message: '数据键值不能为空', trigger: 'blur' }],
-  dictSort: [{ required: true, message: '显示排序不能为空', trigger: 'blur' }]
-}
+/**
+ * Rebuilt whenever the language changes.
+ *
+ * A plain object here is evaluated once, when the page is set up, and the page
+ * is kept alive -- so a message already rendered under a field would keep the
+ * language it was built in. useForm unwraps the ref, so :rules="form.rules" is
+ * unchanged.
+ */
+const rules = computed<FormRules>(() => ({
+  dictLabel: [{ required: true, message: t('admin.dict.data.rules.dictLabel'), trigger: 'blur' }],
+  dictValue: [{ required: true, message: t('admin.dict.data.rules.dictValue'), trigger: 'blur' }],
+  dictSort: [{ required: true, message: t('admin.dict.data.rules.dictSort'), trigger: 'blur' }]
+}))
 
 const form = useForm<SysDictData, number>({
   defaultModel: () => ({
@@ -179,7 +226,13 @@ const form = useForm<SysDictData, number>({
   }),
   idKey: 'dictCode',
   rules,
-  title: { create: '添加字典数据', edit: '修改字典数据' },
+  // Computed, not `t(...)` directly: useForm reads the option on every render,
+  // so a string resolved here once would pin the dialog to the language the
+  // page was opened in.
+  title: {
+    create: computed(() => t('admin.dict.data.addTitle')),
+    edit: computed(() => t('admin.dict.data.editTitle'))
+  },
   api: { get: getDataForForm, add: addData, update: updateData },
   onSuccess: () => table.getList()
 })
@@ -189,7 +242,9 @@ const handleAdd = () => form.openCreate({ dictType: currentType })
 
 const { remove } = useRemove({
   api: delData,
-  confirmText: count => `确认删除选中的 ${count} 条字典数据？`,
+  // The count is both a named value and the plural choice: Chinese needs one
+  // form, English needs two, and passing it twice lets each pack decide.
+  confirmText: count => t('admin.dict.data.removeConfirm', { count }, count),
   onSuccess: () => table.getList()
 })
 </script>

--- a/src/views/admin/dict/index.vue
+++ b/src/views/admin/dict/index.vue
@@ -2,14 +2,29 @@
   <PageContainer>
     <ProTable :table="table" selection row-key="id" :actions-width="120">
       <template #search>
-        <el-form-item label="字典名称">
-          <el-input v-model="table.query.dictName" placeholder="请输入字典名称" clearable style="width: 160px" />
+        <el-form-item :label="$t('admin.dict.type.dictName')">
+          <el-input
+            v-model="table.query.dictName"
+            :placeholder="$t('admin.dict.type.dictNamePlaceholder')"
+            clearable
+            style="width: 160px"
+          />
         </el-form-item>
-        <el-form-item label="字典类型">
-          <el-input v-model="table.query.dictType" placeholder="请输入字典类型" clearable style="width: 160px" />
+        <el-form-item :label="$t('admin.dict.type.dictType')">
+          <el-input
+            v-model="table.query.dictType"
+            :placeholder="$t('admin.dict.type.dictTypePlaceholder')"
+            clearable
+            style="width: 160px"
+          />
         </el-form-item>
-        <el-form-item label="状态">
-          <el-select v-model="table.query.status" placeholder="字典状态" clearable style="width: 130px">
+        <el-form-item :label="$t('admin.dict.type.status')">
+          <el-select
+            v-model="table.query.status"
+            :placeholder="$t('admin.dict.type.statusPlaceholder')"
+            clearable
+            style="width: 130px"
+          >
             <el-option
               v-for="item in sys_normal_disable"
               :key="item.value"
@@ -21,20 +36,34 @@
       </template>
 
       <template #toolbar>
-        <el-button v-permisaction="['admin:sysDictType:add']" type="primary" @click="form.openCreate()">新增</el-button>
+        <el-button v-permisaction="['admin:sysDictType:add']" type="primary" @click="form.openCreate()">
+          {{ $t('common.add') }}
+        </el-button>
         <el-button
           v-permisaction="['admin:sysDictType:remove']"
           type="danger"
           plain
           :disabled="table.multiple"
           @click="remove(table.selectedIds)"
-        >删除</el-button>
-        <el-button v-permisaction="['admin:sysDictType:export']" :loading="exporting" @click="handleExport">导出</el-button>
+        >{{ $t('common.delete') }}</el-button>
+        <el-button v-permisaction="['admin:sysDictType:export']" :loading="exporting" @click="handleExport">
+          {{ $t('common.export') }}
+        </el-button>
       </template>
 
-      <el-table-column label="编号" prop="id" width="80" />
-      <el-table-column label="字典名称" prop="dictName" min-width="140" show-overflow-tooltip />
-      <el-table-column label="字典类型" prop="dictType" min-width="160" show-overflow-tooltip>
+      <el-table-column :label="$t('admin.dict.type.dictId')" prop="id" width="80" />
+      <el-table-column
+        :label="$t('admin.dict.type.dictName')"
+        prop="dictName"
+        min-width="140"
+        show-overflow-tooltip
+      />
+      <el-table-column
+        :label="$t('admin.dict.type.dictType')"
+        prop="dictType"
+        min-width="160"
+        show-overflow-tooltip
+      >
         <template #default="{ row }">
           <!-- The entries live on their own page, keyed by this record's id -->
           <router-link :to="{ name: 'SysDictDataManage', params: { dictId: row.id }}" class="link-type">
@@ -42,60 +71,81 @@
           </router-link>
         </template>
       </el-table-column>
-      <el-table-column label="状态" prop="status" width="90">
+      <el-table-column :label="$t('admin.dict.type.status')" prop="status" width="90">
         <template #default="{ row }">
           <el-tag :type="Number(row.status) === 2 ? 'success' : 'danger'" disable-transitions>
             {{ dictLabel(sys_normal_disable, row.status) }}
           </el-tag>
         </template>
       </el-table-column>
-      <el-table-column label="备注" prop="remark" min-width="160" show-overflow-tooltip />
+      <el-table-column
+        :label="$t('admin.dict.type.remark')"
+        prop="remark"
+        min-width="160"
+        show-overflow-tooltip
+      />
       <!--
         Not sortable: SysDictTypeOrder binds dictIdOrder and nothing else, so a
         header on this column would send createdAtOrder, which gin drops.
       -->
-      <el-table-column label="创建时间" prop="createdAt" min-width="110">
+      <el-table-column :label="$t('common.createdAt')" prop="createdAt" min-width="110">
         <template #default="{ row }"><DateCell :value="row.createdAt" /></template>
       </el-table-column>
 
       <template #actions="{ row }">
         <el-button v-permisaction="['admin:sysDictType:edit']" link type="primary" @click="form.openEdit(row)">
-          修改
+          {{ $t('common.edit') }}
         </el-button>
         <el-button v-permisaction="['admin:sysDictType:remove']" link type="danger" @click="remove(row.id)">
-          删除
+          {{ $t('common.delete') }}
         </el-button>
       </template>
     </ProTable>
 
     <el-dialog v-model="form.visible" :title="form.title" width="500px" :close-on-click-modal="false">
       <el-form :ref="form.bindFormRef" :model="form.model" :rules="form.rules" label-width="90px">
-        <el-form-item label="字典名称" prop="dictName">
-          <el-input v-model="form.model.dictName" placeholder="请输入字典名称" :disabled="form.isEdit" />
+        <el-form-item :label="$t('admin.dict.type.dictName')" prop="dictName">
+          <el-input
+            v-model="form.model.dictName"
+            :placeholder="$t('admin.dict.type.dictNamePlaceholder')"
+            :disabled="form.isEdit"
+          />
         </el-form-item>
-        <el-form-item label="字典类型" prop="dictType">
-          <el-input v-model="form.model.dictType" placeholder="请输入字典类型" :disabled="form.isEdit" />
+        <el-form-item :label="$t('admin.dict.type.dictType')" prop="dictType">
+          <el-input
+            v-model="form.model.dictType"
+            :placeholder="$t('admin.dict.type.dictTypePlaceholder')"
+            :disabled="form.isEdit"
+          />
         </el-form-item>
-        <el-form-item label="状态" prop="status">
+        <el-form-item :label="$t('admin.dict.type.status')" prop="status">
           <el-radio-group v-model="form.model.status">
             <el-radio v-for="item in sys_normal_disable" :key="item.value" :value="item.value">
               {{ item.label }}
             </el-radio>
           </el-radio-group>
         </el-form-item>
-        <el-form-item label="备注" prop="remark">
-          <el-input v-model="form.model.remark" type="textarea" placeholder="请输入内容" />
+        <el-form-item :label="$t('admin.dict.type.remark')" prop="remark">
+          <el-input
+            v-model="form.model.remark"
+            type="textarea"
+            :placeholder="$t('admin.dict.type.remarkPlaceholder')"
+          />
         </el-form-item>
       </el-form>
       <template #footer>
-        <el-button @click="form.close()">取 消</el-button>
-        <el-button type="primary" :loading="form.submitting" @click="form.submit()">确 定</el-button>
+        <el-button @click="form.close()">{{ $t('common.dialogCancel') }}</el-button>
+        <el-button type="primary" :loading="form.submitting" @click="form.submit()">
+          {{ $t('common.dialogConfirm') }}
+        </el-button>
       </template>
     </el-dialog>
   </PageContainer>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { FormRules } from 'element-plus'
 
 import PageContainer from '@/components/PageContainer/index.vue'
@@ -110,6 +160,8 @@ import type { SysDictType, SysDictTypeQuery } from '@/types/admin'
 // Must match the menu_name the backend serves, or keep-alive silently misses
 defineOptions({ name: 'Dict' })
 
+const { t } = useI18n()
+
 const { sys_normal_disable } = useDict('sys_normal_disable')
 
 const table = useTable<SysDictType, SysDictTypeQuery>({
@@ -118,10 +170,18 @@ const table = useTable<SysDictType, SysDictTypeQuery>({
   defaultQuery: () => ({ dictName: undefined, dictType: undefined, status: undefined })
 })
 
-const rules: FormRules = {
-  dictName: [{ required: true, message: '字典名称不能为空', trigger: 'blur' }],
-  dictType: [{ required: true, message: '字典类型不能为空', trigger: 'blur' }]
-}
+/**
+ * Rebuilt whenever the language changes.
+ *
+ * A plain object here is evaluated once, when the page is set up, and the page
+ * is kept alive -- so a message already rendered under a field would keep the
+ * language it was built in. useForm unwraps the ref, so :rules="form.rules" is
+ * unchanged.
+ */
+const rules = computed<FormRules>(() => ({
+  dictName: [{ required: true, message: t('admin.dict.type.rules.dictName'), trigger: 'blur' }],
+  dictType: [{ required: true, message: t('admin.dict.type.rules.dictType'), trigger: 'blur' }]
+}))
 
 const form = useForm<SysDictType, number>({
   defaultModel: () => ({
@@ -133,23 +193,39 @@ const form = useForm<SysDictType, number>({
   }),
   idKey: 'id',
   rules,
-  title: { create: '添加字典类型', edit: '修改字典类型' },
+  // Computed, not `t(...)` directly: useForm reads the option on every render,
+  // so a string resolved here once would pin the dialog to the language the
+  // page was opened in.
+  title: {
+    create: computed(() => t('admin.dict.type.addTitle')),
+    edit: computed(() => t('admin.dict.type.editTitle'))
+  },
   api: { get: getTypeForForm, add: addType, update: updateType },
   onSuccess: () => table.getList()
 })
 
 const { remove } = useRemove({
   api: delType,
-  confirmText: count => `确认删除选中的 ${count} 个字典类型？`,
+  // The count is both a named value and the plural choice: Chinese needs one
+  // form, English needs two, and passing it twice lets each pack decide.
+  confirmText: count => t('admin.dict.type.removeConfirm', { count }, count),
   onSuccess: () => table.getList()
 })
 
 const { exportExcel, exporting } = useExport()
 
+// Built on each click rather than once, so the sheet is written in the
+// language the reader is in when they ask for it.
 const handleExport = () => exportExcel({
-  header: ['编号', '字典名称', '字典类型', '状态', '备注'],
+  header: [
+    t('admin.dict.type.exportHeader.dictId'),
+    t('admin.dict.type.exportHeader.dictName'),
+    t('admin.dict.type.exportHeader.dictType'),
+    t('admin.dict.type.exportHeader.status'),
+    t('admin.dict.type.exportHeader.remark')
+  ],
   fields: ['id', 'dictName', 'dictType', 'status', 'remark'],
   rows: table.rows as Array<Record<string, unknown>>,
-  filename: '字典类型'
+  filename: t('admin.dict.type.exportFilename')
 })
 </script>

--- a/src/views/admin/sys-api/index.vue
+++ b/src/views/admin/sys-api/index.vue
@@ -2,42 +2,76 @@
   <PageContainer>
     <ProTable :table="table" row-key="id" :actions-width="80">
       <template #search>
-        <el-form-item label="标题">
-          <el-input v-model="table.query.title" placeholder="请输入标题" clearable style="width: 160px" />
+        <el-form-item :label="$t('admin.sysApi.title')">
+          <el-input
+            v-model="table.query.title"
+            :placeholder="$t('admin.sysApi.titlePlaceholder')"
+            clearable
+            style="width: 160px"
+          />
         </el-form-item>
-        <el-form-item label="地址">
-          <el-input v-model="table.query.path" placeholder="请输入地址" clearable style="width: 200px" />
+        <el-form-item :label="$t('admin.sysApi.path')">
+          <el-input
+            v-model="table.query.path"
+            :placeholder="$t('admin.sysApi.pathPlaceholder')"
+            clearable
+            style="width: 200px"
+          />
         </el-form-item>
         <el-form-item label="Method">
-          <el-select v-model="table.query.action" placeholder="请选择" clearable style="width: 120px">
+          <el-select
+            v-model="table.query.action"
+            :placeholder="$t('admin.sysApi.selectPlaceholder')"
+            clearable
+            style="width: 120px"
+          >
             <el-option v-for="method in METHODS" :key="method" :value="method" :label="method" />
           </el-select>
         </el-form-item>
-        <el-form-item label="类型">
-          <el-select v-model="table.query.type" placeholder="请选择" clearable style="width: 110px">
+        <el-form-item :label="$t('admin.sysApi.type')">
+          <el-select
+            v-model="table.query.type"
+            :placeholder="$t('admin.sysApi.selectPlaceholder')"
+            clearable
+            style="width: 110px"
+          >
             <el-option value="SYS" label="SYS" />
             <el-option value="BUS" label="BUS" />
           </el-select>
         </el-form-item>
       </template>
 
-      <el-table-column label="标题" prop="title" min-width="240" sortable="custom" show-overflow-tooltip>
+      <el-table-column
+        :label="$t('admin.sysApi.title')"
+        prop="title"
+        min-width="240"
+        sortable="custom"
+        show-overflow-tooltip
+      >
         <template #default="{ row }">
           <!-- SYS routes are infrastructure and cannot be granted to a role,
                which is the distinction the colour carries. -->
-          <el-tag v-if="!row.title" type="danger" disable-transitions>暂无</el-tag>
+          <el-tag v-if="!row.title" type="danger" disable-transitions>{{ $t('admin.sysApi.none') }}</el-tag>
           <el-tag v-else :type="row.type === 'SYS' ? 'success' : 'info'" disable-transitions>
             [{{ row.type }}] {{ row.title }}
           </el-tag>
         </template>
       </el-table-column>
 
-      <el-table-column label="接口" prop="path" min-width="280" sortable="custom" show-overflow-tooltip>
+      <el-table-column
+        :label="$t('admin.sysApi.api')"
+        prop="path"
+        min-width="280"
+        sortable="custom"
+        show-overflow-tooltip
+      >
         <template #default="{ row }">
           <el-popover trigger="hover" placement="top" :width="360">
-            <p class="peek-line">Handle：{{ row.handle || '-' }}</p>
-            <p class="peek-line">类型：{{ row.type || '-' }}</p>
-            <p class="peek-line">标题：{{ row.title || '暂无' }}</p>
+            <p class="peek-line">{{ $t('admin.sysApi.peekHandle', { value: row.handle || '-' }) }}</p>
+            <p class="peek-line">{{ $t('admin.sysApi.peekType', { value: row.type || '-' }) }}</p>
+            <p class="peek-line">
+              {{ $t('admin.sysApi.peekTitle', { value: row.title || $t('admin.sysApi.none') }) }}
+            </p>
             <template #reference>
               <span><MethodTag :method="row.action" /> {{ row.path }}</span>
             </template>
@@ -45,13 +79,13 @@
         </template>
       </el-table-column>
 
-      <el-table-column label="创建时间" prop="createdAt" min-width="120" sortable="custom">
+      <el-table-column :label="$t('common.createdAt')" prop="createdAt" min-width="120" sortable="custom">
         <template #default="{ row }"><DateCell :value="row.createdAt" /></template>
       </el-table-column>
 
       <template #actions="{ row }">
         <el-button v-permisaction="['admin:sysApi:edit']" link type="primary" @click="form.openEdit(row)">
-          修改
+          {{ $t('common.edit') }}
         </el-button>
       </template>
     </ProTable>
@@ -65,35 +99,47 @@
         <el-form-item label="Handle" prop="handle">
           <el-input v-model="form.model.handle" placeholder="handle" />
         </el-form-item>
-        <el-form-item label="标题" prop="title">
-          <el-input v-model="form.model.title" placeholder="标题" />
+        <el-form-item :label="$t('admin.sysApi.title')" prop="title">
+          <el-input v-model="form.model.title" :placeholder="$t('admin.sysApi.title')" />
         </el-form-item>
-        <el-form-item label="类型" prop="type">
-          <el-select v-model="form.model.type" placeholder="请选择类型" style="width: 100%">
+        <el-form-item :label="$t('admin.sysApi.type')" prop="type">
+          <el-select
+            v-model="form.model.type"
+            :placeholder="$t('admin.sysApi.typePlaceholder')"
+            style="width: 100%"
+          >
             <el-option value="SYS" label="SYS" />
             <el-option value="BUS" label="BUS" />
           </el-select>
         </el-form-item>
         <el-form-item label="Method" prop="action">
-          <el-select v-model="form.model.action" placeholder="请选择方式" style="width: 100%">
+          <el-select
+            v-model="form.model.action"
+            :placeholder="$t('admin.sysApi.actionPlaceholder')"
+            style="width: 100%"
+          >
             <el-option v-for="method in METHODS" :key="method" :value="method" :label="method" />
           </el-select>
         </el-form-item>
-        <el-form-item label="地址" prop="path">
+        <el-form-item :label="$t('admin.sysApi.path')" prop="path">
           <!-- The path identifies the route; the backend registers it, so it is
                shown for confirmation rather than offered for editing. -->
-          <el-input v-model="form.model.path" disabled placeholder="地址" />
+          <el-input v-model="form.model.path" disabled :placeholder="$t('admin.sysApi.path')" />
         </el-form-item>
       </el-form>
       <template #footer>
-        <el-button @click="form.close()">取 消</el-button>
-        <el-button type="primary" :loading="form.submitting" @click="form.submit()">确 定</el-button>
+        <el-button @click="form.close()">{{ $t('common.dialogCancel') }}</el-button>
+        <el-button type="primary" :loading="form.submitting" @click="form.submit()">
+          {{ $t('common.dialogConfirm') }}
+        </el-button>
       </template>
     </el-drawer>
   </PageContainer>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { FormRules } from 'element-plus'
 
 import PageContainer from '@/components/PageContainer/index.vue'
@@ -108,6 +154,8 @@ import type { SysApi, SysApiQuery } from '@/types/admin'
 // Must match the menu_name the backend serves, or keep-alive silently misses
 defineOptions({ name: 'SysApiManage' })
 
+const { t } = useI18n()
+
 const METHODS = ['GET', 'POST', 'PUT', 'DELETE']
 
 /**
@@ -121,11 +169,19 @@ const table = useTable<SysApi, SysApiQuery>({
   defaultQuery: () => ({ title: undefined, path: undefined, action: undefined, type: undefined })
 })
 
-const rules: FormRules = {
-  handle: [{ required: true, message: 'handle 不能为空', trigger: 'blur' }],
-  title: [{ required: true, message: '标题不能为空', trigger: 'blur' }],
-  type: [{ required: true, message: '类型不能为空', trigger: 'change' }]
-}
+/**
+ * Rebuilt whenever the language changes.
+ *
+ * A plain object here is evaluated once, when the page is set up, and the page
+ * is kept alive -- so a message already rendered under a field would keep the
+ * language it was built in. useForm unwraps the ref, so :rules="form.rules" is
+ * unchanged.
+ */
+const rules = computed<FormRules>(() => ({
+  handle: [{ required: true, message: t('admin.sysApi.rules.handle'), trigger: 'blur' }],
+  title: [{ required: true, message: t('admin.sysApi.rules.title'), trigger: 'blur' }],
+  type: [{ required: true, message: t('admin.sysApi.rules.type'), trigger: 'change' }]
+}))
 
 const form = useForm<SysApi, number>({
   defaultModel: () => ({
@@ -138,7 +194,13 @@ const form = useForm<SysApi, number>({
   }),
   idKey: 'id',
   rules,
-  title: { create: '添加接口', edit: '修改接口' },
+  // Computed, not `t(...)` directly: useForm reads the option on every render,
+  // so a string resolved here once would pin the drawer to the language the
+  // page was opened in.
+  title: {
+    create: computed(() => t('admin.sysApi.addTitle')),
+    edit: computed(() => t('admin.sysApi.editTitle'))
+  },
   api: { get: getSysApi, update: updateSysApi },
   onSuccess: () => table.getList()
 })

--- a/src/views/admin/sys-config/set.vue
+++ b/src/views/admin/sys-config/set.vue
@@ -4,15 +4,15 @@
 
       <div class="config-wrapper">
 
-        <!-- ── 左侧导航 ── -->
+        <!-- ── Sidebar ── -->
         <div class="config-sidebar">
           <div class="sidebar-header">
             <div class="sidebar-icon-box">
               <el-icon :size="18" class="accent-icon"><Setting /></el-icon>
             </div>
             <div>
-              <p class="sidebar-header__title">系统配置</p>
-              <p class="sidebar-header__sub">基础信息与外观设置</p>
+              <p class="sidebar-header__title">{{ $t('admin.sysConfig.set.sidebarTitle') }}</p>
+              <p class="sidebar-header__sub">{{ $t('admin.sysConfig.set.sidebarSub') }}</p>
             </div>
           </div>
           <div class="sidebar-divider" />
@@ -33,10 +33,10 @@
           </div>
         </div>
 
-        <!-- ── 右侧主内容 ── -->
+        <!-- ── Main pane ── -->
         <div class="config-main">
 
-          <!-- 基础信息 -->
+          <!-- Basic information -->
           <transition name="fade-slide" mode="out-in">
             <div v-if="activeSection === 0" key="basic" class="config-section">
               <div class="section-head">
@@ -44,8 +44,8 @@
                   <el-icon :size="16" class="accent-icon"><OfficeBuilding /></el-icon>
                 </div>
                 <div>
-                  <p class="section-head__title">系统基础信息</p>
-                  <p class="section-head__desc">配置系统名称、Logo 及用户默认密码</p>
+                  <p class="section-head__title">{{ $t('admin.sysConfig.set.basicTitle') }}</p>
+                  <p class="section-head__desc">{{ $t('admin.sysConfig.set.basicDesc') }}</p>
                 </div>
               </div>
 
@@ -56,12 +56,12 @@
                     <img v-if="form.sys_app_logo" :src="form.sys_app_logo" alt="logo" class="logo-img">
                     <div v-else class="logo-empty">
                       <el-icon :size="24"><Picture /></el-icon>
-                      <span>暂无 Logo</span>
+                      <span>{{ $t('admin.sysConfig.set.logoEmpty') }}</span>
                     </div>
                   </div>
                   <div class="logo-meta">
-                    <p class="logo-meta__name">系统 Logo</p>
-                    <p class="logo-meta__hint">推荐 200×200，支持 JPG / PNG，大小不超过 2MB</p>
+                    <p class="logo-meta__name">{{ $t('admin.sysConfig.set.logoName') }}</p>
+                    <p class="logo-meta__hint">{{ $t('admin.sysConfig.set.logoHint') }}</p>
                     <el-upload
                       :headers="uploadHeaders"
                       :action="uploadAction"
@@ -70,7 +70,7 @@
                       :on-success="onLogoUploaded"
                     >
                       <el-button size="small" plain type="primary">
-                        <el-icon style="margin-right:4px"><Upload /></el-icon>上传图片
+                        <el-icon style="margin-right:4px"><Upload /></el-icon>{{ $t('admin.sysConfig.set.upload') }}
                       </el-button>
                     </el-upload>
                   </div>
@@ -81,15 +81,24 @@
                 <el-form ref="formRef" :model="form" :rules="rules" label-position="top">
                   <el-row :gutter="20">
                     <el-col :span="12">
-                      <el-form-item label="系统名称" prop="sys_app_name">
-                        <el-input v-model="form.sys_app_name" placeholder="请输入系统名称" clearable>
+                      <el-form-item :label="$t('admin.sysConfig.set.appName')" prop="sys_app_name">
+                        <el-input
+                          v-model="form.sys_app_name"
+                          :placeholder="$t('admin.sysConfig.set.appNamePlaceholder')"
+                          clearable
+                        >
                           <template #prefix><el-icon><OfficeBuilding /></el-icon></template>
                         </el-input>
                       </el-form-item>
                     </el-col>
                     <el-col :span="12">
-                      <el-form-item label="用户初始密码" prop="sys_user_initPassword">
-                        <el-input v-model="form.sys_user_initPassword" placeholder="请输入初始密码" clearable show-password>
+                      <el-form-item :label="$t('admin.sysConfig.set.initPassword')" prop="sys_user_initPassword">
+                        <el-input
+                          v-model="form.sys_user_initPassword"
+                          :placeholder="$t('admin.sysConfig.set.initPasswordPlaceholder')"
+                          clearable
+                          show-password
+                        >
                           <template #prefix><el-icon><Lock /></el-icon></template>
                         </el-input>
                       </el-form-item>
@@ -99,15 +108,15 @@
               </div>
             </div>
 
-            <!-- 外观设置 -->
+            <!-- Appearance -->
             <div v-else-if="activeSection === 1" key="theme" class="config-section">
               <div class="section-head">
                 <div class="section-head__icon-wrap">
                   <el-icon :size="16" class="accent-icon"><Brush /></el-icon>
                 </div>
                 <div>
-                  <p class="section-head__title">外观设置</p>
-                  <p class="section-head__desc">调整皮肤样式与侧栏主题风格</p>
+                  <p class="section-head__title">{{ $t('admin.sysConfig.set.appearance') }}</p>
+                  <p class="section-head__desc">{{ $t('admin.sysConfig.set.appearanceDesc') }}</p>
                 </div>
               </div>
 
@@ -115,23 +124,31 @@
                 <el-form label-position="top">
                   <el-row :gutter="20">
                     <el-col :span="12">
-                      <el-form-item label="皮肤样式">
-                        <el-select v-model="form.sys_index_skinName" placeholder="请选择皮肤样式" style="width:100%">
-                          <el-option v-for="(item, i) in sys_index_skinNameOptions" :key="i" :label="item.label" :value="item.value" />
+                      <el-form-item :label="$t('admin.sysConfig.set.skin')">
+                        <el-select
+                          v-model="form.sys_index_skinName"
+                          :placeholder="$t('admin.sysConfig.set.skinPlaceholder')"
+                          style="width:100%"
+                        >
+                          <el-option v-for="(item, i) in skinOptions" :key="i" :label="item.label" :value="item.value" />
                         </el-select>
                       </el-form-item>
                     </el-col>
                     <el-col :span="12">
-                      <el-form-item label="侧栏主题">
-                        <el-select v-model="form.sys_index_sideTheme" placeholder="请选择侧栏主题" style="width:100%">
-                          <el-option v-for="(item, i) in sys_index_sideThemeOptions" :key="i" :label="item.label" :value="item.value" />
+                      <el-form-item :label="$t('admin.sysConfig.set.sideTheme')">
+                        <el-select
+                          v-model="form.sys_index_sideTheme"
+                          :placeholder="$t('admin.sysConfig.set.sideThemePlaceholder')"
+                          style="width:100%"
+                        >
+                          <el-option v-for="(item, i) in sideThemeOptions" :key="i" :label="item.label" :value="item.value" />
                         </el-select>
                       </el-form-item>
                     </el-col>
                   </el-row>
                 </el-form>
 
-                <p class="theme-label">点击快速切换主题</p>
+                <p class="theme-label">{{ $t('admin.sysConfig.set.themeHint') }}</p>
                 <div class="theme-row">
                   <div
                     class="theme-card"
@@ -146,7 +163,7 @@
                       </div>
                     </div>
                     <div class="tc-label">
-                      <span>深色主题</span>
+                      <span>{{ $t('admin.sysConfig.set.themeDark') }}</span>
                       <el-icon v-if="form.sys_index_sideTheme === 'theme-dark'" class="accent-icon"><Check /></el-icon>
                     </div>
                   </div>
@@ -163,7 +180,7 @@
                       </div>
                     </div>
                     <div class="tc-label">
-                      <span>浅色主题</span>
+                      <span>{{ $t('admin.sysConfig.set.themeLight') }}</span>
                       <el-icon v-if="form.sys_index_sideTheme === 'theme-light'" class="accent-icon"><Check /></el-icon>
                     </div>
                   </div>
@@ -172,10 +189,12 @@
             </div>
           </transition>
 
-          <!-- 操作栏 -->
+          <!-- Footer -->
           <div class="config-footer">
-            <el-button :loading="loading" @click="load">重置</el-button>
-            <el-button type="primary" :loading="saving" @click="submit">保存设置</el-button>
+            <el-button :loading="loading" @click="load">{{ $t('common.reset') }}</el-button>
+            <el-button type="primary" :loading="saving" @click="submit">
+              {{ $t('admin.sysConfig.set.save') }}
+            </el-button>
           </div>
 
         </div>
@@ -186,7 +205,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, shallowRef, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { FormInstance, FormRules, UploadProps } from 'element-plus'
 import { ElMessage } from 'element-plus'
 import { OfficeBuilding, Lock, Picture, Upload, Brush, Check, Setting } from '@element-plus/icons-vue'
@@ -199,6 +219,8 @@ import { msgSuccess } from '@/utils/message'
 
 // Must match the menu_name the backend serves, or keep-alive silently misses
 defineOptions({ name: 'SysConfigSet' })
+
+const { t } = useI18n()
 
 /**
  * The settings this page owns, and the only keys it will ever send.
@@ -225,23 +247,51 @@ const loading = ref(false)
 const saving = ref(false)
 const activeSection = ref(0)
 
-const rules: FormRules = {
-  sys_app_name: [{ required: true, message: '请输入系统名称', trigger: 'blur' }],
-  sys_user_initPassword: [{ required: true, message: '请输入初始密码', trigger: 'blur' }]
-}
+/**
+ * Rebuilt whenever the language changes.
+ *
+ * A plain object is evaluated once, when the page is set up, and this page is
+ * kept alive -- so a message already rendered under a field would keep the
+ * language it was built in. el-form revalidates when its rules change, which is
+ * what repaints one that is already on screen.
+ */
+const rules = computed<FormRules>(() => ({
+  sys_app_name: [{ required: true, message: t('admin.sysConfig.set.rules.appName'), trigger: 'blur' }],
+  sys_user_initPassword: [
+    { required: true, message: t('admin.sysConfig.set.rules.initPassword'), trigger: 'blur' }
+  ]
+}))
 
-// shallowRef: these are component definitions, and making them deeply reactive
-// buys nothing while costing a walk of every icon's internals
-const navItems = shallowRef([
-  { label: '基础信息', sub: '名称、Logo、密码', icon: OfficeBuilding },
-  { label: '外观设置', sub: '皮肤与主题风格', icon: Brush }
+/**
+ * The two sections of the page, rebuilt whenever the language changes.
+ *
+ * A computed rather than the shallowRef this replaces: the labels are the point
+ * of the list, and a plain array built at setup would keep the language the
+ * page was opened in. The icons ride along as plain component definitions --
+ * a computed hands its value back untouched, so nothing walks their internals,
+ * which is what the shallowRef was avoiding.
+ */
+const navItems = computed(() => [
+  {
+    label: t('admin.sysConfig.set.basic'),
+    sub: t('admin.sysConfig.set.basicSub'),
+    icon: OfficeBuilding
+  },
+  {
+    label: t('admin.sysConfig.set.appearance'),
+    sub: t('admin.sysConfig.set.appearanceSub'),
+    icon: Brush
+  }
 ])
 
-const sys_index_skinNameOptions = [{ label: '蓝色', value: 'skin-blue' }]
-const sys_index_sideThemeOptions = [
-  { label: '深色主题', value: 'theme-dark' },
-  { label: '浅色主题', value: 'theme-light' }
-]
+const skinOptions = computed(() => [
+  { label: t('admin.sysConfig.set.skinBlue'), value: 'skin-blue' }
+])
+
+const sideThemeOptions = computed(() => [
+  { label: t('admin.sysConfig.set.themeDark'), value: 'theme-dark' },
+  { label: t('admin.sysConfig.set.themeLight'), value: 'theme-light' }
+])
 
 /**
  * Doubles as the reset button.
@@ -278,7 +328,11 @@ const submit = async() => {
     const entries = Object.entries(form.value)
       .map(([configKey, configValue]) => ({ configKey, configValue }))
     const response = await updateSetConfig(entries)
-    msgSuccess(response.msg || '保存成功')
+    // The server's own message still wins, which is what renders today -- the
+    // endpoint answers 更新成功. It is Chinese in either language, and that is
+    // the one string on this page a switch cannot reach; translating the
+    // backend's messages is its own change.
+    msgSuccess(response.msg || t('admin.sysConfig.set.saveOk'))
 
     // The name and logo are in the shell, so the store has to hear about it
     useSystemStore().setInfo({
@@ -302,7 +356,7 @@ const uploadAction = process.env.VUE_APP_BASE_API + '/api/v1/public/uploadFile'
 
 const beforeLogoUpload: UploadProps['beforeUpload'] = file => {
   const withinLimit = file.size / 1024 / 1024 < 2
-  if (!withinLimit) ElMessage.error('文件大小超过 2MB')
+  if (!withinLimit) ElMessage.error(t('admin.sysConfig.set.logoTooLarge'))
   return withinLimit
 }
 
@@ -320,7 +374,7 @@ const onLogoUploaded: UploadProps['onSuccess'] = response => {
   color: var(--ga-brand);
 }
 
-// ── 页面容器 ──────────────────────────────────────────────
+// ── Page container ────────────────────────────────────────
 .sys-config-set {
   padding: 0;
 }
@@ -332,7 +386,7 @@ const onLogoUploaded: UploadProps['onSuccess'] = response => {
 }
 
 // ══════════════════════════════
-//  左侧导航卡
+//  Sidebar card
 // ══════════════════════════════
 .config-sidebar {
   width: 188px;
@@ -383,7 +437,7 @@ const onLogoUploaded: UploadProps['onSuccess'] = response => {
   margin: 0;
 }
 
-// 导航项
+// Nav item
 .nav-item {
   display: flex;
   align-items: center;
@@ -439,7 +493,7 @@ const onLogoUploaded: UploadProps['onSuccess'] = response => {
 }
 
 // ══════════════════════════════
-//  右侧主内容
+//  Main pane
 // ══════════════════════════════
 .config-main {
   flex: 1;
@@ -449,7 +503,7 @@ const onLogoUploaded: UploadProps['onSuccess'] = response => {
   gap: 12px;
 }
 
-// 内容分区卡片
+// Section card
 .config-section {
   background: var(--ga-bg-container);
   border-radius: 8px;
@@ -458,7 +512,7 @@ const onLogoUploaded: UploadProps['onSuccess'] = response => {
   overflow: hidden;
 }
 
-// 分区头部
+// Section head
 .section-head {
   display: flex;
   align-items: center;
@@ -494,12 +548,12 @@ const onLogoUploaded: UploadProps['onSuccess'] = response => {
   line-height: 1;
 }
 
-// 分区内容体
+// Section body
 .section-body {
   padding: 16px;
 }
 
-// ── Logo 区域 ──────────────────────────────────────────
+// ── Logo zone ─────────────────────────────────────────────
 .logo-zone {
   display: flex;
   align-items: center;
@@ -554,7 +608,7 @@ const onLogoUploaded: UploadProps['onSuccess'] = response => {
   line-height: 1.5;
 }
 
-// ── 主题选择 ─────────────────────────────────────────────
+// ── Theme picker ──────────────────────────────────────────
 .theme-label {
   margin: 12px 0 10px;
   font-size: 12px;
@@ -626,7 +680,7 @@ const onLogoUploaded: UploadProps['onSuccess'] = response => {
   border-top: 1px solid var(--ga-border-light);
 }
 
-// ── 底部操作栏 ────────────────────────────────────────────
+// ── Footer bar ────────────────────────────────────────────
 .config-footer {
   display: flex;
   justify-content: flex-end;
@@ -638,7 +692,7 @@ const onLogoUploaded: UploadProps['onSuccess'] = response => {
   box-shadow: 0 1px 2px var(--ga-shadow-1, rgba(0,0,0,0.05));
 }
 
-// ── 过渡动画 ─────────────────────────────────────────────
+// ── Transition ────────────────────────────────────────────
 .fade-slide-enter-active,
 .fade-slide-leave-active {
   transition: opacity 0.15s, transform 0.15s;

--- a/src/views/admin/sys-login-log/index.vue
+++ b/src/views/admin/sys-login-log/index.vue
@@ -8,11 +8,21 @@
       :default-sort="{ prop: 'createdAt', order: 'descending' }"
     >
       <template #search>
-        <el-form-item label="用户名">
-          <el-input v-model="table.query.username" placeholder="请输入用户名" clearable style="width: 160px" />
+        <el-form-item :label="$t('admin.sysLoginLog.username')">
+          <el-input
+            v-model="table.query.username"
+            :placeholder="$t('admin.sysLoginLog.usernamePlaceholder')"
+            clearable
+            style="width: 160px"
+          />
         </el-form-item>
-        <el-form-item label="状态">
-          <el-select v-model="table.query.status" placeholder="登录状态" clearable style="width: 140px">
+        <el-form-item :label="$t('admin.sysLoginLog.status')">
+          <el-select
+            v-model="table.query.status"
+            :placeholder="$t('admin.sysLoginLog.statusPlaceholder')"
+            clearable
+            style="width: 140px"
+          >
             <el-option
               v-for="item in sys_common_status"
               :key="item.value"
@@ -21,8 +31,13 @@
             />
           </el-select>
         </el-form-item>
-        <el-form-item label="ip 地址">
-          <el-input v-model="table.query.ipaddr" placeholder="请输入 ip 地址" clearable style="width: 160px" />
+        <el-form-item :label="$t('admin.sysLoginLog.ipaddr')">
+          <el-input
+            v-model="table.query.ipaddr"
+            :placeholder="$t('admin.sysLoginLog.ipaddrPlaceholder')"
+            clearable
+            style="width: 160px"
+          />
         </el-form-item>
       </template>
 
@@ -33,25 +48,35 @@
           plain
           :disabled="table.multiple"
           @click="remove(table.selectedIds)"
-        >删除</el-button>
+        >{{ $t('common.delete') }}</el-button>
       </template>
 
-      <el-table-column label="用户名" prop="username" min-width="110" show-overflow-tooltip />
-      <el-table-column label="类型" prop="msg" min-width="120" show-overflow-tooltip />
-      <el-table-column label="状态" prop="status" width="90">
+      <el-table-column
+        :label="$t('admin.sysLoginLog.username')"
+        prop="username"
+        min-width="110"
+        show-overflow-tooltip
+      />
+      <el-table-column
+        :label="$t('admin.sysLoginLog.msg')"
+        prop="msg"
+        min-width="120"
+        show-overflow-tooltip
+      />
+      <el-table-column :label="$t('admin.sysLoginLog.status')" prop="status" width="90">
         <template #default="{ row }">
           <el-tag :type="Number(row.status) === 2 ? 'success' : 'danger'" disable-transitions>
             {{ dictLabel(sys_common_status, row.status) }}
           </el-tag>
         </template>
       </el-table-column>
-      <el-table-column label="ip 地址" prop="ipaddr" min-width="130">
+      <el-table-column :label="$t('admin.sysLoginLog.ipaddr')" prop="ipaddr" min-width="130">
         <template #default="{ row }">
           <el-popover trigger="hover" placement="top" :width="300">
-            <p class="peek-line">归属地：{{ row.loginLocation || '-' }}</p>
-            <p class="peek-line">浏览器：{{ row.browser || '-' }}</p>
-            <p class="peek-line">系统：{{ row.os || '-' }}</p>
-            <p class="peek-line">固件：{{ row.platform || '-' }}</p>
+            <p class="peek-line">{{ $t('admin.sysLoginLog.peekLocation', { value: row.loginLocation || '-' }) }}</p>
+            <p class="peek-line">{{ $t('admin.sysLoginLog.peekBrowser', { value: row.browser || '-' }) }}</p>
+            <p class="peek-line">{{ $t('admin.sysLoginLog.peekOs', { value: row.os || '-' }) }}</p>
+            <p class="peek-line">{{ $t('admin.sysLoginLog.peekPlatform', { value: row.platform || '-' }) }}</p>
             <template #reference><span>{{ row.ipaddr }}</span></template>
           </el-popover>
         </template>
@@ -65,13 +90,18 @@
         measurement in CLAUDE.md: a sortable header plus `2026-08-01 14:00` needs
         about 141px, or the cells wrap.
       -->
-      <el-table-column label="登录时间" prop="createdAt" min-width="150" sortable="custom">
+      <el-table-column
+        :label="$t('admin.sysLoginLog.loginTime')"
+        prop="createdAt"
+        min-width="150"
+        sortable="custom"
+      >
         <template #default="{ row }"><DateCell :value="row.loginTime" pattern="{y}-{m}-{d} {h}:{i}" /></template>
       </el-table-column>
 
       <template #actions="{ row }">
         <el-button v-permisaction="['admin:sysLoginLog:remove']" link type="danger" @click="remove(row.id)">
-          删除
+          {{ $t('common.delete') }}
         </el-button>
       </template>
     </ProTable>
@@ -79,6 +109,8 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
 import PageContainer from '@/components/PageContainer/index.vue'
 import ProTable from '@/components/ProTable/index.vue'
 import DateCell from '@/components/DateCell/index.vue'
@@ -89,6 +121,8 @@ import type { SysLoginLog, SysLoginLogQuery } from '@/types/admin'
 
 // Must match the menu_name the backend serves, or keep-alive silently misses
 defineOptions({ name: 'SysLoginLogManage' })
+
+const { t } = useI18n()
 
 const { sys_common_status } = useDict('sys_common_status')
 
@@ -110,7 +144,9 @@ const table = useTable<SysLoginLog, SysLoginLogQuery>({
 
 const { remove } = useRemove({
   api: delSysLoginlog,
-  confirmText: count => `确认删除选中的 ${count} 条登录日志？`,
+  // The count is both a named value and the plural choice: Chinese needs one
+  // form, English needs two, and passing it twice lets each pack decide.
+  confirmText: count => t('admin.sysLoginLog.removeConfirm', { count }, count),
   onSuccess: () => table.getList()
 })
 </script>

--- a/src/views/admin/sys-oper-log/index.vue
+++ b/src/views/admin/sys-oper-log/index.vue
@@ -8,11 +8,21 @@
       :default-sort="{ prop: 'createdAt', order: 'descending' }"
     >
       <template #search>
-        <el-form-item label="访问地址">
-          <el-input v-model="table.query.operUrl" placeholder="请输入访问地址" clearable style="width: 180px" />
+        <el-form-item :label="$t('admin.sysOperLog.operUrl')">
+          <el-input
+            v-model="table.query.operUrl"
+            :placeholder="$t('admin.sysOperLog.operUrlPlaceholder')"
+            clearable
+            style="width: 180px"
+          />
         </el-form-item>
-        <el-form-item label="状态">
-          <el-select v-model="table.query.status" placeholder="操作状态" clearable style="width: 130px">
+        <el-form-item :label="$t('admin.sysOperLog.status')">
+          <el-select
+            v-model="table.query.status"
+            :placeholder="$t('admin.sysOperLog.statusPlaceholder')"
+            clearable
+            style="width: 130px"
+          >
             <el-option
               v-for="item in sys_common_status"
               :key="item.value"
@@ -21,13 +31,13 @@
             />
           </el-select>
         </el-form-item>
-        <el-form-item label="操作时间">
+        <el-form-item :label="$t('admin.sysOperLog.operTime')">
           <el-date-picker
             v-model="operatedBetween"
             type="datetimerange"
-            range-separator="至"
-            start-placeholder="开始日期"
-            end-placeholder="结束日期"
+            :range-separator="$t('admin.sysOperLog.rangeSeparator')"
+            :start-placeholder="$t('admin.sysOperLog.startDate')"
+            :end-placeholder="$t('admin.sysOperLog.endDate')"
             value-format="YYYY-MM-DD HH:mm:ss"
             style="width: 340px"
           />
@@ -41,22 +51,27 @@
           plain
           :disabled="table.multiple"
           @click="remove(table.selectedIds)"
-        >删除</el-button>
+        >{{ $t('common.delete') }}</el-button>
         <el-button v-permisaction="['admin:sysOperLog:remove']" type="danger" plain @click="handleClean">
-          清空
+          {{ $t('admin.sysOperLog.clean') }}
         </el-button>
         <el-button v-permisaction="['admin:sysOperLog:export']" :loading="exporting" @click="handleExport">
-          导出
+          {{ $t('common.export') }}
         </el-button>
       </template>
 
-      <el-table-column label="编号" prop="id" min-width="80" />
-      <el-table-column label="请求" prop="operUrl" min-width="220" show-overflow-tooltip>
+      <el-table-column :label="$t('admin.sysOperLog.operId')" prop="id" min-width="80" />
+      <el-table-column
+        :label="$t('admin.sysOperLog.request')"
+        prop="operUrl"
+        min-width="220"
+        show-overflow-tooltip
+      >
         <template #default="{ row }">
           <el-popover trigger="hover" placement="top" :width="360">
-            <p class="peek-line">Host：{{ row.operIp }}</p>
-            <p class="peek-line">归属地：{{ row.operLocation || '-' }}</p>
-            <p class="peek-line">耗时：{{ row.latencyTime || '-' }}</p>
+            <p class="peek-line">{{ $t('admin.sysOperLog.peekHost', { value: row.operIp }) }}</p>
+            <p class="peek-line">{{ $t('admin.sysOperLog.peekLocation', { value: row.operLocation || '-' }) }}</p>
+            <p class="peek-line">{{ $t('admin.sysOperLog.peekLatency', { value: row.latencyTime || '-' }) }}</p>
             <template #reference>
               <span>
                 <MethodTag :method="row.requestMethod" />
@@ -66,8 +81,13 @@
           </el-popover>
         </template>
       </el-table-column>
-      <el-table-column label="操作人员" prop="operName" min-width="130" show-overflow-tooltip />
-      <el-table-column label="状态" prop="status" width="90">
+      <el-table-column
+        :label="$t('admin.sysOperLog.operName')"
+        prop="operName"
+        min-width="130"
+        show-overflow-tooltip
+      />
+      <el-table-column :label="$t('admin.sysOperLog.status')" prop="status" width="90">
         <template #default="{ row }">
           <el-tag :type="Number(row.status) === 2 ? 'success' : 'danger'" disable-transitions>
             {{ dictLabel(sys_common_status, row.status) }}
@@ -76,41 +96,61 @@
       </el-table-column>
       <!-- prop is createdAt because createdAtOrder is the only order key
            SysOperaLogOrder binds; see the same column on the login log page -->
-      <el-table-column label="操作日期" prop="createdAt" min-width="150" sortable="custom">
+      <el-table-column
+        :label="$t('admin.sysOperLog.operDate')"
+        prop="createdAt"
+        min-width="150"
+        sortable="custom"
+      >
         <template #default="{ row }"><DateCell :value="row.operTime" pattern="{y}-{m}-{d} {h}:{i}" /></template>
       </el-table-column>
 
       <template #actions="{ row }">
         <el-button v-permisaction="['admin:sysOperLog:query']" link type="primary" @click="openDetail(row)">
-          详细
+          {{ $t('admin.sysOperLog.detail') }}
         </el-button>
       </template>
     </ProTable>
 
-    <el-dialog v-model="detailOpen" title="操作日志详细" width="720px" :close-on-click-modal="false">
+    <el-dialog
+      v-model="detailOpen"
+      :title="$t('admin.sysOperLog.detailTitle')"
+      width="720px"
+      :close-on-click-modal="false"
+    >
       <el-descriptions :column="2" border>
-        <el-descriptions-item label="请求地址" :span="2">{{ detail.operUrl }}</el-descriptions-item>
-        <el-descriptions-item label="登录信息">
+        <el-descriptions-item :label="$t('admin.sysOperLog.detailUrl')" :span="2">
+          {{ detail.operUrl }}
+        </el-descriptions-item>
+        <el-descriptions-item :label="$t('admin.sysOperLog.loginInfo')">
           {{ detail.operName }} / {{ detail.operIp }} / {{ detail.operLocation || '-' }}
         </el-descriptions-item>
-        <el-descriptions-item label="请求方式">{{ detail.requestMethod }}</el-descriptions-item>
-        <el-descriptions-item label="耗时">{{ detail.latencyTime || '-' }}</el-descriptions-item>
-        <el-descriptions-item label="操作时间">{{ parseTime(detail.operTime) || '-' }}</el-descriptions-item>
-        <el-descriptions-item label="系统模块">{{ detail.title || '-' }}</el-descriptions-item>
-        <el-descriptions-item label="操作状态">
+        <el-descriptions-item :label="$t('admin.sysOperLog.requestMethod')">
+          {{ detail.requestMethod }}
+        </el-descriptions-item>
+        <el-descriptions-item :label="$t('admin.sysOperLog.latency')">
+          {{ detail.latencyTime || '-' }}
+        </el-descriptions-item>
+        <el-descriptions-item :label="$t('admin.sysOperLog.operTime')">
+          {{ parseTime(detail.operTime) || '-' }}
+        </el-descriptions-item>
+        <el-descriptions-item :label="$t('admin.sysOperLog.module')">
+          {{ detail.title || '-' }}
+        </el-descriptions-item>
+        <el-descriptions-item :label="$t('admin.sysOperLog.operStatus')">
           <el-tag :type="Number(detail.status) === 2 ? 'success' : 'danger'" disable-transitions>
             {{ dictLabel(sys_common_status, detail.status) }}
           </el-tag>
         </el-descriptions-item>
-        <el-descriptions-item label="请求参数" :span="2">
+        <el-descriptions-item :label="$t('admin.sysOperLog.operParam')" :span="2">
           <pre class="log-payload">{{ detail.operParam || '-' }}</pre>
         </el-descriptions-item>
-        <el-descriptions-item label="返回参数" :span="2">
+        <el-descriptions-item :label="$t('admin.sysOperLog.jsonResult')" :span="2">
           <pre class="log-payload">{{ detail.jsonResult || '-' }}</pre>
         </el-descriptions-item>
       </el-descriptions>
       <template #footer>
-        <el-button @click="detailOpen = false">关 闭</el-button>
+        <el-button @click="detailOpen = false">{{ $t('admin.sysOperLog.dialogClose') }}</el-button>
       </template>
     </el-dialog>
   </PageContainer>
@@ -118,6 +158,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ElMessageBox } from 'element-plus'
 
 import PageContainer from '@/components/PageContainer/index.vue'
@@ -133,6 +174,8 @@ import type { SysOperaLog, SysOperaLogQuery } from '@/types/admin'
 
 // Must match the menu_name the backend serves, or keep-alive silently misses
 defineOptions({ name: 'OperLog' })
+
+const { t } = useI18n()
 
 const { sys_common_status } = useDict('sys_common_status')
 
@@ -168,7 +211,9 @@ const operatedBetween = computed<[string, string] | null>({
 
 const { remove } = useRemove({
   api: delSysOperlog,
-  confirmText: count => `确认删除选中的 ${count} 条操作日志？`,
+  // The count is both a named value and the plural choice: Chinese needs one
+  // form, English needs two, and passing it twice lets each pack decide.
+  confirmText: count => t('admin.sysOperLog.removeConfirm', { count }, count),
   onSuccess: () => table.getList()
 })
 
@@ -186,10 +231,13 @@ const handleClean = async() => {
   if (cleaning) return
   cleaning = true
   try {
-    await ElMessageBox.confirm('确认清空全部操作日志？此操作不可撤销。', '提示', {
+    // Every string read here rather than once at setup, so the box follows the
+    // language even after the page has been sitting open -- the same reason
+    // useRemove resolves its own four inside the call.
+    await ElMessageBox.confirm(t('admin.sysOperLog.cleanConfirm'), t('common.notice'), {
       type: 'warning',
-      confirmButtonText: '确定',
-      cancelButtonText: '取消'
+      confirmButtonText: t('common.confirm'),
+      cancelButtonText: t('common.cancel')
     })
   } catch {
     cleaning = false
@@ -197,7 +245,7 @@ const handleClean = async() => {
   }
   try {
     await cleanOperlog()
-    msgSuccess('已清空')
+    msgSuccess(t('admin.sysOperLog.cleanOk'))
     // search, not getList: the log is empty now, so whatever page the user was
     // on no longer exists
     await table.search()
@@ -218,11 +266,24 @@ const openDetail = (row: SysOperaLog) => {
 
 const { exportExcel, exporting } = useExport()
 
+// Built on each click rather than once, so the sheet is written in the
+// language the reader is in when they ask for it.
 const handleExport = () => exportExcel({
-  header: ['编号', '系统模块', '操作类型', '操作人员', '主机', '操作地点', '请求方式', '请求地址', '状态', '操作日期'],
+  header: [
+    t('admin.sysOperLog.exportHeader.operId'),
+    t('admin.sysOperLog.exportHeader.module'),
+    t('admin.sysOperLog.exportHeader.businessType'),
+    t('admin.sysOperLog.exportHeader.operName'),
+    t('admin.sysOperLog.exportHeader.operIp'),
+    t('admin.sysOperLog.exportHeader.operLocation'),
+    t('admin.sysOperLog.exportHeader.requestMethod'),
+    t('admin.sysOperLog.exportHeader.operUrl'),
+    t('admin.sysOperLog.exportHeader.status'),
+    t('admin.sysOperLog.exportHeader.operDate')
+  ],
   fields: ['id', 'title', 'businessType', 'operName', 'operIp', 'operLocation', 'requestMethod', 'operUrl', 'status', 'operTime'],
   rows: table.rows as Array<Record<string, unknown>>,
-  filename: '操作日志'
+  filename: t('admin.sysOperLog.exportFilename')
 })
 </script>
 

--- a/src/views/admin/sys-post/index.vue
+++ b/src/views/admin/sys-post/index.vue
@@ -2,14 +2,29 @@
   <PageContainer>
     <ProTable :table="table" selection row-key="postId" :actions-width="120">
       <template #search>
-        <el-form-item label="岗位编码">
-          <el-input v-model="table.query.postCode" placeholder="请输入岗位编码" clearable style="width: 160px" />
+        <el-form-item :label="$t('admin.sysPost.postCode')">
+          <el-input
+            v-model="table.query.postCode"
+            :placeholder="$t('admin.sysPost.postCodePlaceholder')"
+            clearable
+            style="width: 160px"
+          />
         </el-form-item>
-        <el-form-item label="岗位名称">
-          <el-input v-model="table.query.postName" placeholder="请输入岗位名称" clearable style="width: 160px" />
+        <el-form-item :label="$t('admin.sysPost.postName')">
+          <el-input
+            v-model="table.query.postName"
+            :placeholder="$t('admin.sysPost.postNamePlaceholder')"
+            clearable
+            style="width: 160px"
+          />
         </el-form-item>
-        <el-form-item label="状态">
-          <el-select v-model="table.query.status" placeholder="岗位状态" clearable style="width: 140px">
+        <el-form-item :label="$t('admin.sysPost.status')">
+          <el-select
+            v-model="table.query.status"
+            :placeholder="$t('admin.sysPost.statusPlaceholder')"
+            clearable
+            style="width: 140px"
+          >
             <el-option
               v-for="item in sys_normal_disable"
               :key="item.value"
@@ -22,48 +37,58 @@
 
       <template #toolbar>
         <el-button v-permisaction="['admin:sysPost:add']" type="primary" @click="form.openCreate()">
-          新增
+          {{ $t('common.add') }}
         </el-button>
         <el-button
           v-permisaction="['admin:sysPost:edit']"
           :disabled="table.single"
           @click="form.openEdit(table.selection[0])"
-        >修改</el-button>
+        >{{ $t('common.edit') }}</el-button>
         <el-button
           v-permisaction="['admin:sysPost:remove']"
           type="danger"
           plain
           :disabled="table.multiple"
           @click="remove(table.selectedIds)"
-        >删除</el-button>
+        >{{ $t('common.delete') }}</el-button>
         <el-button
           v-permisaction="['admin:sysPost:export']"
           :loading="exporting"
           @click="handleExport"
-        >导出</el-button>
+        >{{ $t('common.export') }}</el-button>
       </template>
 
-      <el-table-column label="岗位编号" prop="postId" min-width="90" />
-      <el-table-column label="岗位编码" prop="postCode" min-width="120" show-overflow-tooltip />
-      <el-table-column label="岗位名称" prop="postName" min-width="120" show-overflow-tooltip />
-      <el-table-column label="岗位排序" prop="sort" min-width="90" />
-      <el-table-column label="状态" prop="status" min-width="90">
+      <el-table-column :label="$t('admin.sysPost.postId')" prop="postId" min-width="90" />
+      <el-table-column
+        :label="$t('admin.sysPost.postCode')"
+        prop="postCode"
+        min-width="120"
+        show-overflow-tooltip
+      />
+      <el-table-column
+        :label="$t('admin.sysPost.postName')"
+        prop="postName"
+        min-width="120"
+        show-overflow-tooltip
+      />
+      <el-table-column :label="$t('admin.sysPost.postSort')" prop="sort" min-width="90" />
+      <el-table-column :label="$t('admin.sysPost.status')" prop="status" min-width="90">
         <template #default="{ row }">
           <el-tag :type="Number(row.status) === 1 ? 'danger' : 'success'" disable-transitions>
             {{ dictLabel(sys_normal_disable, row.status) }}
           </el-tag>
         </template>
       </el-table-column>
-      <el-table-column label="创建时间" prop="createdAt" min-width="110">
+      <el-table-column :label="$t('common.createdAt')" prop="createdAt" min-width="110">
         <template #default="{ row }"><DateCell :value="row.createdAt" /></template>
       </el-table-column>
 
       <template #actions="{ row }">
         <el-button v-permisaction="['admin:sysPost:edit']" link type="primary" @click="form.openEdit(row)">
-          修改
+          {{ $t('common.edit') }}
         </el-button>
         <el-button v-permisaction="['admin:sysPost:remove']" link type="danger" @click="remove(row.postId)">
-          删除
+          {{ $t('common.delete') }}
         </el-button>
       </template>
     </ProTable>
@@ -82,16 +107,16 @@
         :rules="form.rules"
         label-width="88px"
       >
-        <el-form-item label="岗位名称" prop="postName">
-          <el-input v-model="form.model.postName" placeholder="请输入岗位名称" />
+        <el-form-item :label="$t('admin.sysPost.postName')" prop="postName">
+          <el-input v-model="form.model.postName" :placeholder="$t('admin.sysPost.postNamePlaceholder')" />
         </el-form-item>
-        <el-form-item label="岗位编码" prop="postCode">
-          <el-input v-model="form.model.postCode" placeholder="请输入编码名称" />
+        <el-form-item :label="$t('admin.sysPost.postCode')" prop="postCode">
+          <el-input v-model="form.model.postCode" :placeholder="$t('admin.sysPost.codeNamePlaceholder')" />
         </el-form-item>
-        <el-form-item label="岗位顺序" prop="sort">
+        <el-form-item :label="$t('admin.sysPost.sort')" prop="sort">
           <el-input-number v-model="form.model.sort" controls-position="right" :min="0" />
         </el-form-item>
-        <el-form-item label="岗位状态" prop="status">
+        <el-form-item :label="$t('admin.sysPost.postStatus')" prop="status">
           <el-radio-group v-model="form.model.status">
             <el-radio
               v-for="item in sys_normal_disable"
@@ -100,19 +125,25 @@
             >{{ item.label }}</el-radio>
           </el-radio-group>
         </el-form-item>
-        <el-form-item label="备注" prop="remark">
-          <el-input v-model="form.model.remark" type="textarea" placeholder="请输入内容" />
+        <el-form-item :label="$t('admin.sysPost.remark')" prop="remark">
+          <el-input
+            v-model="form.model.remark"
+            type="textarea"
+            :placeholder="$t('admin.sysPost.remarkPlaceholder')"
+          />
         </el-form-item>
       </el-form>
       <template #footer>
-        <el-button @click="form.close">取 消</el-button>
-        <el-button type="primary" :loading="form.submitting" @click="form.submit">确 定</el-button>
+        <el-button @click="form.close">{{ $t('common.dialogCancel') }}</el-button>
+        <el-button type="primary" :loading="form.submitting" @click="form.submit">{{ $t('common.dialogConfirm') }}</el-button>
       </template>
     </el-dialog>
   </PageContainer>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { FormRules } from 'element-plus'
 
 import PageContainer from '@/components/PageContainer/index.vue'
@@ -127,6 +158,8 @@ import type { SysPost, SysPostQuery } from '@/types/admin'
 // Must match the menu_name the backend serves, or keep-alive silently misses
 defineOptions({ name: 'SysPostManage' })
 
+const { t } = useI18n()
+
 const { sys_normal_disable } = useDict('sys_normal_disable')
 
 const table = useTable<SysPost, SysPostQuery>({
@@ -135,11 +168,19 @@ const table = useTable<SysPost, SysPostQuery>({
   defaultQuery: () => ({ postCode: undefined, postName: undefined, status: undefined })
 })
 
-const rules: FormRules = {
-  postName: [{ required: true, message: '岗位名称不能为空', trigger: 'blur' }],
-  postCode: [{ required: true, message: '岗位编码不能为空', trigger: 'blur' }],
-  sort: [{ required: true, message: '岗位顺序不能为空', trigger: 'blur' }]
-}
+/**
+ * Rebuilt whenever the language changes.
+ *
+ * A plain object here is evaluated once, when the page is set up, and the page
+ * is kept alive -- so a message already rendered under a field would keep the
+ * language it was built in. useForm unwraps the ref, so :rules="form.rules" is
+ * unchanged.
+ */
+const rules = computed<FormRules>(() => ({
+  postName: [{ required: true, message: t('admin.sysPost.rules.postName'), trigger: 'blur' }],
+  postCode: [{ required: true, message: t('admin.sysPost.rules.postCode'), trigger: 'blur' }],
+  sort: [{ required: true, message: t('admin.sysPost.rules.sort'), trigger: 'blur' }]
+}))
 
 const form = useForm<SysPost, number>({
   defaultModel: () => ({
@@ -152,7 +193,13 @@ const form = useForm<SysPost, number>({
   }),
   idKey: 'postId',
   rules,
-  title: { create: '添加岗位', edit: '修改岗位' },
+  // Computed, not `t(...)` directly: useForm reads the option on every render,
+  // so a string resolved here once would pin the dialog to the language the
+  // page was opened in.
+  title: {
+    create: computed(() => t('admin.sysPost.addTitle')),
+    edit: computed(() => t('admin.sysPost.editTitle'))
+  },
   api: {
     get: getPostForForm,
     add: addPost,
@@ -168,10 +215,18 @@ const { remove } = useRemove({
 
 const { exportExcel, exporting } = useExport()
 
+// Built on each click rather than once, so the sheet is written in the
+// language the reader is in when they ask for it.
 const handleExport = () => exportExcel({
-  header: ['岗位编号', '岗位编码', '岗位名称', '排序', '创建时间'],
+  header: [
+    t('admin.sysPost.exportHeader.postId'),
+    t('admin.sysPost.exportHeader.postCode'),
+    t('admin.sysPost.exportHeader.postName'),
+    t('admin.sysPost.exportHeader.sort'),
+    t('admin.sysPost.exportHeader.createdAt')
+  ],
   fields: ['postId', 'postCode', 'postName', 'sort', 'createdAt'],
   rows: table.rows as Array<Record<string, unknown>>,
-  filename: '岗位管理'
+  filename: t('admin.sysPost.exportFilename')
 })
 </script>

--- a/src/views/demo/product/index.vue
+++ b/src/views/demo/product/index.vue
@@ -4,13 +4,13 @@
       <!-- Search fields. No prop attributes needed: resetQuery rebuilds the
            query from its factory rather than asking el-form to reset itself -->
       <template #search>
-        <el-form-item label="名称">
-          <el-input v-model="table.query.name" placeholder="请输入名称" clearable />
+        <el-form-item :label="$t('demo.name')">
+          <el-input v-model="table.query.name" :placeholder="$t('demo.namePlaceholder')" clearable />
         </el-form-item>
-        <el-form-item label="状态">
-          <el-select v-model="table.query.status" placeholder="请选择状态" clearable style="width: 120px">
-            <el-option label="正常" value="1" />
-            <el-option label="停用" value="2" />
+        <el-form-item :label="$t('demo.status')">
+          <el-select v-model="table.query.status" :placeholder="$t('demo.statusPlaceholder')" clearable style="width: 120px">
+            <el-option :label="$t('demo.normal')" value="1" />
+            <el-option :label="$t('demo.disabled')" value="2" />
           </el-select>
         </el-form-item>
       </template>
@@ -18,7 +18,7 @@
       <!-- Permission codes are 模块:资源:操作 and must match sys_menu -->
       <template #toolbar>
         <el-button v-permisaction="['demo:product:add']" type="primary" @click="form.openCreate()">
-          新增
+          {{ $t('common.add') }}
         </el-button>
         <!-- Plain while it needs a selection; see AGENTS.md -->
         <el-button
@@ -28,30 +28,30 @@
           :disabled="table.multiple"
           @click="remove(table.selectedIds)"
         >
-          删除
+          {{ $t('common.delete') }}
         </el-button>
       </template>
 
       <!-- min-width, not width: see AGENTS.md -->
-      <el-table-column label="名称" prop="name" min-width="120" show-overflow-tooltip />
-      <el-table-column label="编码" prop="code" min-width="100" />
-      <el-table-column label="单价" prop="price" min-width="90" align="right" />
-      <el-table-column label="状态" prop="status" min-width="90">
+      <el-table-column :label="$t('demo.name')" prop="name" min-width="120" show-overflow-tooltip />
+      <el-table-column :label="$t('demo.code')" prop="code" min-width="100" />
+      <el-table-column :label="$t('demo.price')" prop="price" min-width="90" align="right" />
+      <el-table-column :label="$t('demo.status')" prop="status" min-width="90">
         <template #default="{ row }">
           <el-tag :type="row.status === '1' ? 'success' : 'info'">
-            {{ row.status === '1' ? '正常' : '停用' }}
+            {{ row.status === '1' ? $t('demo.normal') : $t('demo.disabled') }}
           </el-tag>
         </template>
       </el-table-column>
-      <el-table-column label="创建时间" min-width="110">
+      <el-table-column :label="$t('common.createdAt')" min-width="110">
         <template #default="{ row }"><DateCell :value="row.createdAt" /></template>
       </el-table-column>
       <template #actions="{ row }">
         <el-button v-permisaction="['demo:product:edit']" link type="primary" @click="form.openEdit(row)">
-          修改
+          {{ $t('common.edit') }}
         </el-button>
         <el-button v-permisaction="['demo:product:delete']" link type="danger" @click="remove(row.id)">
-          删除
+          {{ $t('common.delete') }}
         </el-button>
       </template>
     </ProTable>
@@ -71,28 +71,28 @@
         :rules="form.rules"
         label-width="80px"
       >
-        <el-form-item label="名称" prop="name">
-          <el-input v-model="form.model.name" placeholder="请输入名称" />
+        <el-form-item :label="$t('demo.name')" prop="name">
+          <el-input v-model="form.model.name" :placeholder="$t('demo.namePlaceholder')" />
         </el-form-item>
-        <el-form-item label="编码" prop="code">
-          <el-input v-model="form.model.code" placeholder="请输入编码" />
+        <el-form-item :label="$t('demo.code')" prop="code">
+          <el-input v-model="form.model.code" :placeholder="$t('demo.codePlaceholder')" />
         </el-form-item>
-        <el-form-item label="单价" prop="price">
+        <el-form-item :label="$t('demo.price')" prop="price">
           <el-input-number v-model="form.model.price" :min="0" :precision="2" />
         </el-form-item>
-        <el-form-item label="状态" prop="status">
+        <el-form-item :label="$t('demo.status')" prop="status">
           <el-radio-group v-model="form.model.status">
-            <el-radio value="1">正常</el-radio>
-            <el-radio value="2">停用</el-radio>
+            <el-radio value="1">{{ $t('demo.normal') }}</el-radio>
+            <el-radio value="2">{{ $t('demo.disabled') }}</el-radio>
           </el-radio-group>
         </el-form-item>
-        <el-form-item label="备注" prop="remark">
-          <el-input v-model="form.model.remark" type="textarea" placeholder="请输入内容" />
+        <el-form-item :label="$t('demo.remark')" prop="remark">
+          <el-input v-model="form.model.remark" type="textarea" :placeholder="$t('demo.remarkPlaceholder')" />
         </el-form-item>
       </el-form>
       <template #footer>
-        <el-button @click="form.close">取 消</el-button>
-        <el-button type="primary" :loading="form.submitting" @click="form.submit">确 定</el-button>
+        <el-button @click="form.close">{{ $t('common.dialogCancel') }}</el-button>
+        <el-button type="primary" :loading="form.submitting" @click="form.submit">{{ $t('common.dialogConfirm') }}</el-button>
       </template>
     </el-dialog>
   </PageContainer>
@@ -107,6 +107,8 @@
  * useTable and useForm. What is left is what actually differs: which endpoints,
  * which columns, which fields, which rules.
  */
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { FormRules } from 'element-plus'
 
 import PageContainer from '@/components/PageContainer/index.vue'
@@ -128,10 +130,15 @@ const table = useTable<Product, ProductQuery>({
   defaultQuery: () => ({ name: undefined, status: undefined })
 })
 
-const rules: FormRules = {
-  name: [{ required: true, message: '名称不能为空', trigger: 'blur' }],
-  code: [{ required: true, message: '编码不能为空', trigger: 'blur' }]
-}
+const { t } = useI18n()
+
+// Computed, not a constant: module scope is evaluated once, so messages built
+// from t() there would keep the language the module loaded in -- including one
+// already displayed under a field. useForm accepts a MaybeRef.
+const rules = computed<FormRules>(() => ({
+  name: [{ required: true, message: t('demo.rules.name'), trigger: 'blur' }],
+  code: [{ required: true, message: t('demo.rules.code'), trigger: 'blur' }]
+}))
 
 const form = useForm<Product, number>({
   defaultModel: () => ({

--- a/src/views/dev-tools/gen/basicInfoForm.vue
+++ b/src/views/dev-tools/gen/basicInfoForm.vue
@@ -3,25 +3,52 @@
     <el-row>
       <el-col :span="12">
         <el-form-item prop="tableName">
-          <template #label><FieldLabel label="数据表名称" tip="数据库表名称，针对gorm对应的table()使用，⚠️这里必须是蛇形结构" /></template>
-          <el-input v-model="model.tableName" placeholder="请输入表名称" />
+          <template #label>
+            <FieldLabel
+              :label="$t('devTools.basicInfoForm.tableName')"
+              :tip="$t('devTools.basicInfoForm.tableNameTip')"
+            />
+          </template>
+          <el-input
+            v-model="model.tableName"
+            :placeholder="$t('devTools.basicInfoForm.tableNamePlaceholder')"
+          />
         </el-form-item>
       </el-col>
       <el-col :span="12">
         <el-form-item prop="tableComment">
-          <template #label><FieldLabel label="菜单名称" tip="同步的数据库表名称，生成配置数据时，用作菜单名称" /></template>
-          <el-input v-model="model.tableComment" placeholder="请输入菜单名称" />
+          <template #label>
+            <FieldLabel
+              :label="$t('devTools.basicInfoForm.tableComment')"
+              :tip="$t('devTools.basicInfoForm.tableCommentTip')"
+            />
+          </template>
+          <el-input
+            v-model="model.tableComment"
+            :placeholder="$t('devTools.basicInfoForm.tableCommentPlaceholder')"
+          />
         </el-form-item>
       </el-col>
       <el-col :span="12">
         <el-form-item prop="className">
-          <template #label><FieldLabel label="结构体模型名称" tip="结构体模型名称，代码中的struct名称定义使用" /></template>
-          <el-input v-model="model.className" placeholder="请输入" />
+          <template #label>
+            <FieldLabel
+              :label="$t('devTools.basicInfoForm.className')"
+              :tip="$t('devTools.basicInfoForm.classNameTip')"
+            />
+          </template>
+          <el-input
+            v-model="model.className"
+            :placeholder="$t('devTools.basicInfoForm.classNamePlaceholder')"
+          />
         </el-form-item>
       </el-col>
       <el-col :span="12">
-        <el-form-item label="作者名称" prop="functionAuthor">
-          <el-input v-model="model.functionAuthor" placeholder="请输入作者名称" />
+        <el-form-item :label="$t('devTools.basicInfoForm.functionAuthor')" prop="functionAuthor">
+          <el-input
+            v-model="model.functionAuthor"
+            :placeholder="$t('devTools.basicInfoForm.functionAuthorPlaceholder')"
+          />
         </el-form-item>
       </el-col>
       <!-- <el-col :span="12">
@@ -40,7 +67,7 @@
         </el-form-item>
       </el-col> -->
       <el-col :span="24">
-        <el-form-item label="备注" prop="remark">
+        <el-form-item :label="$t('devTools.basicInfoForm.remark')" prop="remark">
           <el-input v-model="model.remark" type="textarea" :rows="3" />
         </el-form-item>
       </el-col>
@@ -48,13 +75,14 @@
   </el-form>
 </template>
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { FormInstance, FormRules } from 'element-plus'
 import FieldLabel from '@/components/FieldLabel/index.vue'
 import type { GenTable } from '@/api/tools/gen'
 
 /**
- * The 基本信息 tab.
+ * The Basic Information tab.
  *
  * Holds the record through defineModel rather than copying a prop into local
  * state and emitting back. The previous version did the copy, but the parent
@@ -64,25 +92,51 @@ import type { GenTable } from '@/api/tools/gen'
  */
 defineOptions({ name: 'BasicInfoForm' })
 
+const { t } = useI18n()
+
 const model = defineModel<GenTable>({ required: true })
 
 const formRef = ref<FormInstance>()
 
-const rules: FormRules = {
+/**
+ * Rebuilt whenever the language changes.
+ *
+ * A plain object here is evaluated once, when the component is set up, so a
+ * message already rendered under a field would keep the language it was built
+ * in -- and this page is kept alive, so re-entering it does not re-run setup
+ * either. el-form revalidates when its rules change (validateOnRuleChange),
+ * which is what repaints a message that is already on screen. The template
+ * unwraps the ref, so :rules="rules" is unchanged.
+ */
+const rules = computed<FormRules>(() => ({
   tableName: [
-    { required: true, message: '请输入表名称', trigger: 'blur' },
-    { pattern: /^[a-z._]*$/, trigger: 'blur', message: '只允许小写字母，例如 sys_demo' }
+    { required: true, message: t('devTools.basicInfoForm.rules.tableName'), trigger: 'blur' },
+    {
+      pattern: /^[a-z._]*$/,
+      trigger: 'blur',
+      message: t('devTools.basicInfoForm.rules.tableNamePattern')
+    }
   ],
-  tableComment: [{ required: true, message: '请输入菜单名称', trigger: 'blur' }],
+  tableComment: [
+    { required: true, message: t('devTools.basicInfoForm.rules.tableComment'), trigger: 'blur' }
+  ],
   className: [
-    { required: true, message: '请输入模型名称', trigger: 'blur' },
-    { pattern: /^[A-Z][A-Za-z0-9]*$/, trigger: 'blur', message: '必须以大写字母开头，例如 SysDemo' }
+    { required: true, message: t('devTools.basicInfoForm.rules.className'), trigger: 'blur' },
+    {
+      pattern: /^[A-Z][A-Za-z0-9]*$/,
+      trigger: 'blur',
+      message: t('devTools.basicInfoForm.rules.classNamePattern')
+    }
   ],
   functionAuthor: [
-    { required: true, message: '请输入作者', trigger: 'blur' },
-    { pattern: /^[A-Za-z]+$/, trigger: 'blur', message: '只允许字母 a-z 或 A-Z' }
+    { required: true, message: t('devTools.basicInfoForm.rules.functionAuthor'), trigger: 'blur' },
+    {
+      pattern: /^[A-Za-z]+$/,
+      trigger: 'blur',
+      message: t('devTools.basicInfoForm.rules.functionAuthorPattern')
+    }
   ]
-}
+}))
 
 /** The parent validates both tabs before it submits. */
 defineExpose({ validate: () => formRef.value?.validate().catch(() => false) })

--- a/src/views/dev-tools/gen/editTable.vue
+++ b/src/views/dev-tools/gen/editTable.vue
@@ -1,36 +1,36 @@
 <template>
   <el-card>
     <el-tabs v-model="activeName">
-      <el-tab-pane label="基本信息" name="basic">
+      <el-tab-pane :label="$t('devTools.editTable.tabBasic')" name="basic">
         <BasicInfoForm ref="basicForm" v-model="info" />
       </el-tab-pane>
-      <el-tab-pane label="字段信息" name="cloum">
+      <el-tab-pane :label="$t('devTools.editTable.tabColumns')" name="cloum">
         <el-alert
-          title="⚠️表字段中的id、create_by、update_by、created_at、updated_at、deleted_at的字段在此列表中已经隐藏"
+          :title="$t('devTools.editTable.hiddenColumns')"
           type="warning"
           show-icon
         />
         <el-table :data="columns" max-height="calc(100vh - 300px)" style="width: 100%">
-          <el-table-column fixed label="序号" type="index" width="50" />
+          <el-table-column fixed :label="$t('devTools.editTable.index')" type="index" width="50" />
           <el-table-column
             fixed
-            label="字段列名"
+            :label="$t('devTools.editTable.columnName')"
             prop="columnName"
             width="150"
             :show-overflow-tooltip="true"
           />
-          <el-table-column fixed label="字段描述" width="150">
+          <el-table-column fixed :label="$t('devTools.editTable.columnComment')" width="150">
             <template #default="scope">
               <el-input v-model="scope.row.columnComment" />
             </template>
           </el-table-column>
           <el-table-column
-            label="物理类型"
+            :label="$t('devTools.editTable.columnType')"
             prop="columnType"
             width="120"
             :show-overflow-tooltip="true"
           />
-          <el-table-column label="go类型" width="120">
+          <el-table-column :label="$t('devTools.editTable.goType')" width="120">
             <template #default="scope">
               <el-select v-model="scope.row.goType">
                 <el-option label="int64" value="int64" />
@@ -40,18 +40,18 @@
               </el-select>
             </template>
           </el-table-column>
-          <el-table-column label="go属性" width="150">
+          <el-table-column :label="$t('devTools.editTable.goField')" width="150">
             <template #default="scope">
               <el-input v-model="scope.row.goField" />
             </template>
           </el-table-column>
-          <el-table-column label="json属性" width="150">
+          <el-table-column :label="$t('devTools.editTable.jsonField')" width="150">
             <template #default="scope">
               <el-input v-model="scope.row.jsonField" />
             </template>
           </el-table-column>
 
-          <el-table-column label="编辑" width="50">
+          <el-table-column :label="$t('devTools.editTable.isInsert')" width="50">
             <template #default="scope">
               <el-checkbox v-model="scope.row.isInsert" true-value="1" false-value="0" />
             </template>
@@ -63,19 +63,29 @@
             whole header row with it: the table rendered with zero <th> and no
             column labels at all.
           -->
-          <el-table-column label="列表" width="80" align="center">
-            <template #header><FieldLabel label="列表" tip="是否在列表中展示，打勾表示展示" /></template>
+          <el-table-column :label="$t('devTools.editTable.isList')" width="80" align="center">
+            <template #header>
+              <FieldLabel
+                :label="$t('devTools.editTable.isList')"
+                :tip="$t('devTools.editTable.isListTip')"
+              />
+            </template>
             <template #default="scope">
               <el-checkbox v-model="scope.row.isList" true-value="1" false-value="0" />
             </template>
           </el-table-column>
-          <el-table-column label="查询" width="80" align="center">
-            <template #header><FieldLabel label="查询" tip="是否作为搜索条件，打勾表示作为条件" /></template>
+          <el-table-column :label="$t('devTools.editTable.isQuery')" width="80" align="center">
+            <template #header>
+              <FieldLabel
+                :label="$t('devTools.editTable.isQuery')"
+                :tip="$t('devTools.editTable.isQueryTip')"
+              />
+            </template>
             <template #default="scope">
               <el-checkbox v-model="scope.row.isQuery" true-value="1" false-value="0" />
             </template>
           </el-table-column>
-          <el-table-column label="查询方式" width="120">
+          <el-table-column :label="$t('devTools.editTable.queryType')" width="120">
             <template #default="scope">
               <el-select v-model="scope.row.queryType">
                 <el-option label="=" value="EQ" />
@@ -89,43 +99,54 @@
               </el-select>
             </template>
           </el-table-column>
-          <el-table-column label="必填" width="50">
+          <el-table-column :label="$t('devTools.editTable.isRequired')" width="50">
             <template #default="scope">
               <el-checkbox v-model="scope.row.isRequired" true-value="1" false-value="0" />
             </template>
           </el-table-column>
-          <el-table-column label="显示类型" width="140">
+          <el-table-column :label="$t('devTools.editTable.htmlType')" width="140">
             <template #default="scope">
               <el-select v-model="scope.row.htmlType">
-                <el-option label="文本框" value="input" />
-                <el-option label="下拉框" value="select" />
-                <el-option label="单选框" value="radio" />
+                <el-option :label="$t('devTools.editTable.htmlTypes.input')" value="input" />
+                <el-option :label="$t('devTools.editTable.htmlTypes.select')" value="select" />
+                <el-option :label="$t('devTools.editTable.htmlTypes.radio')" value="radio" />
                 <!-- <el-option label="文件选择" value="file" /> -->
                 <!-- <el-option label="复选框" value="checkbox" />
                 <el-option label="日期控件" value="datetime" />-->
-                <el-option label="文本域" value="textarea" />
+                <el-option :label="$t('devTools.editTable.htmlTypes.textarea')" value="textarea" />
 
               </el-select>
             </template>
           </el-table-column>
-          <el-table-column label="字典类型" width="160">
+          <el-table-column :label="$t('devTools.editTable.dictType')" width="160">
             <template #default="scope">
-              <el-select v-model="scope.row.dictType" clearable filterable placeholder="请选择">
+              <el-select
+                v-model="scope.row.dictType"
+                clearable
+                filterable
+                :placeholder="$t('devTools.editTable.selectPlaceholder')"
+              >
                 <el-option
                   v-for="dict in dictOptions"
                   :key="dict.dictType"
-                  :label="dict.dictName"
+                  :label="dictTypeName(dict)"
                   :value="dict.dictType"
                 >
-                  <span style="float: left">{{ dict.dictName }}</span>
+                  <span style="float: left">{{ dictTypeName(dict) }}</span>
                   <span style="float: right; color: #8492a6; font-size: 13px">{{ dict.dictType }}</span>
                 </el-option>
               </el-select>
             </template>
           </el-table-column>
-          <el-table-column label="关系表" width="160">
+          <el-table-column :label="$t('devTools.editTable.fkTableName')" width="160">
             <template #default="scope">
-              <el-select v-model="scope.row.fkTableName" clearable filterable placeholder="请选择" @change="attachForeignColumns(scope.row)">
+              <el-select
+                v-model="scope.row.fkTableName"
+                clearable
+                filterable
+                :placeholder="$t('devTools.editTable.selectPlaceholder')"
+                @change="attachForeignColumns(scope.row)"
+              >
                 <el-option
                   v-for="table in tableTree"
                   :key="table.tableName"
@@ -138,9 +159,14 @@
               </el-select>
             </template>
           </el-table-column>
-          <el-table-column label="关系表key" width="150">
+          <el-table-column :label="$t('devTools.editTable.fkLabelId')" width="150">
             <template #default="scope">
-              <el-select v-model="scope.row.fkLabelId" clearable filterable placeholder="请选择">
+              <el-select
+                v-model="scope.row.fkLabelId"
+                clearable
+                filterable
+                :placeholder="$t('devTools.editTable.selectPlaceholder')"
+              >
                 <el-option
                   v-for="column in scope.row.fkCol"
                   :key="column.columnName"
@@ -153,9 +179,14 @@
               </el-select>
             </template>
           </el-table-column>
-          <el-table-column label="关系表value" width="150">
+          <el-table-column :label="$t('devTools.editTable.fkLabelName')" width="150">
             <template #default="scope">
-              <el-select v-model="scope.row.fkLabelName" clearable filterable placeholder="请选择">
+              <el-select
+                v-model="scope.row.fkLabelName"
+                clearable
+                filterable
+                :placeholder="$t('devTools.editTable.selectPlaceholder')"
+              >
                 <el-option
                   v-for="column in scope.row.fkCol"
                   :key="column.columnName"
@@ -170,25 +201,29 @@
           </el-table-column>
         </el-table>
       </el-tab-pane>
-      <el-tab-pane label="生成信息" name="genInfo">
+      <el-tab-pane :label="$t('devTools.editTable.tabGen')" name="genInfo">
         <GenInfoForm ref="genForm" v-model="info" />
       </el-tab-pane>
     </el-tabs>
     <el-form label-width="100px">
       <el-form-item style="text-align: center;margin-left:-100px;margin-top:10px;">
-        <el-button @click="close()">返回</el-button>
-        <el-button type="primary" :loading="saving" @click="submit()">提交</el-button>
+        <el-button @click="close()">{{ $t('devTools.editTable.back') }}</el-button>
+        <el-button type="primary" :loading="saving" @click="submit()">
+          {{ $t('devTools.editTable.submit') }}
+        </el-button>
       </el-form-item>
     </el-form>
   </el-card>
 </template>
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
 import FieldLabel from '@/components/FieldLabel/index.vue'
 import BasicInfoForm from './basicInfoForm.vue'
 import GenInfoForm from './genInfoForm.vue'
+import { translateDictTypeName } from '@/lang/backend'
 import { useTagsViewStore } from '@/stores/tagsView'
 import { msgSuccess, msgError } from '@/utils/message'
 
@@ -200,6 +235,7 @@ import type { SysDictType } from '@/types/admin'
 // Must match the menu_name the backend serves, or keep-alive silently misses
 defineOptions({ name: 'EditTable' })
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 
@@ -220,9 +256,20 @@ const basicForm = ref<{ validate: () => Promise<unknown> }>()
 const genForm = ref<{ validate: () => Promise<unknown> }>()
 
 /**
+ * The dictionary picker's option text.
+ *
+ * These names come from the database, so they arrive in Chinese whatever the
+ * interface language is -- but the seeded ones have a translation keyed by
+ * dict_type, which is what lang/backend.ts looks up. A dictionary the operator
+ * created has none and falls back to its stored name, which is also what zh-CN
+ * always gets: that language ships no dict.ts on purpose.
+ */
+const dictTypeName = (dict: SysDictType) => translateDictTypeName(dict.dictType, dict.dictName)
+
+/**
  * The relation pickers offer the columns of whichever table a row points at.
  *
- * Empty rather than a 请选择 placeholder row: the two el-options below bind
+ * Empty rather than a placeholder row: the two el-options below bind
  * `:value="column.jsonField"`, which that row does not carry, so it rendered an
  * option whose value was undefined and Element Plus warned on every one of them.
  * el-select shows its own placeholder when it has no options.
@@ -273,7 +320,7 @@ const submit = async() => {
   if (saving.value) return
   const results = await Promise.all([basicForm.value?.validate(), genForm.value?.validate()])
   if (!results.every(Boolean)) {
-    msgError('表单校验未通过，请重新检查提交内容')
+    msgError(t('devTools.editTable.validationFailed'))
     return
   }
 
@@ -293,7 +340,7 @@ const submit = async() => {
       isAuth: info.value.isAuth === 'true'
     }
     const response = await updateGenTable(payload)
-    msgSuccess(response.msg || '保存成功')
+    msgSuccess(response.msg || t('devTools.editTable.saveSuccess'))
     await close()
   } catch {
     // Reported by the interceptor

--- a/src/views/dev-tools/gen/genInfoForm.vue
+++ b/src/views/dev-tools/gen/genInfoForm.vue
@@ -3,9 +3,9 @@
     <el-row>
       <el-col :span="12">
         <el-form-item prop="tplCategory">
-          <template #label>生成模板</template>
+          <template #label>{{ $t('devTools.genInfoForm.tplCategory') }}</template>
           <el-select v-model="model.tplCategory">
-            <el-option label="关系表（增删改查）" value="crud" />
+            <el-option :label="$t('devTools.genInfoForm.tplCrud')" value="crud" />
             <!-- <el-option label="关系表（增删改查）" value="mcrud" />
             <el-option label="树表（增删改查）" value="tree" /> -->
           </el-select>
@@ -14,8 +14,8 @@
 
       <el-col :span="12">
         <el-form-item prop="packageName">
-          <template #label>应用名
-            <el-tooltip content="应用名，例如：在app文件夹下将该功能发到那个应用中，默认：admin" placement="top">
+          <template #label>{{ $t('devTools.genInfoForm.packageName') }}
+            <el-tooltip :content="$t('devTools.genInfoForm.packageNameTip')" placement="top">
               <i class="ri-question-line" />
             </el-tooltip></template>
           <el-input v-model="model.packageName" />
@@ -34,8 +34,8 @@
 
       <el-col :span="12">
         <el-form-item prop="businessName">
-          <template #label>业务名
-            <el-tooltip content="可理解为功能英文名，例如 user" placement="top">
+          <template #label>{{ $t('devTools.genInfoForm.businessName') }}
+            <el-tooltip :content="$t('devTools.genInfoForm.businessNameTip')" placement="top">
               <i class="ri-question-line" />
             </el-tooltip></template>
           <el-input v-model="model.businessName" />
@@ -44,8 +44,8 @@
 
       <el-col :span="12">
         <el-form-item prop="functionName">
-          <template #label>功能描述
-            <el-tooltip content="同步的数据库表备注，用作类描述，例如：用户" placement="top">
+          <template #label>{{ $t('devTools.genInfoForm.functionName') }}
+            <el-tooltip :content="$t('devTools.genInfoForm.functionNameTip')" placement="top">
               <i class="ri-question-line" />
             </el-tooltip></template>
           <el-input v-model="model.functionName" />
@@ -53,8 +53,8 @@
       </el-col>
       <el-col :span="12">
         <el-form-item prop="moduleName">
-          <template #label>接口路径
-            <el-tooltip content="接口路径，例如：api/v1/{sys-user}" placement="top">
+          <template #label>{{ $t('devTools.genInfoForm.moduleName') }}
+            <el-tooltip :content="$t('devTools.genInfoForm.moduleNameTip')" placement="top">
               <i class="ri-question-line" />
             </el-tooltip></template>
           <el-input v-model="model.moduleName">
@@ -107,14 +107,17 @@
     </el-row>
 
     <el-row v-show="model.tplCategory == 'tree'">
-      <h4 class="form-header">其他信息</h4>
+      <h4 class="form-header">{{ $t('devTools.genInfoForm.otherInfo') }}</h4>
       <el-col :span="12">
         <el-form-item>
-          <template #label>树编码字段
-            <el-tooltip content="树显示的编码字段名， 如：dept_id" placement="top">
+          <template #label>{{ $t('devTools.genInfoForm.treeCode') }}
+            <el-tooltip :content="$t('devTools.genInfoForm.treeCodeTip')" placement="top">
               <i class="ri-question-line" />
             </el-tooltip></template>
-          <el-select v-model="model.treeCode" placeholder="请选择">
+          <el-select
+            v-model="model.treeCode"
+            :placeholder="$t('devTools.genInfoForm.selectPlaceholder')"
+          >
             <el-option
               v-for="column in columns"
               :key="column.columnName"
@@ -126,11 +129,14 @@
       </el-col>
       <el-col :span="12">
         <el-form-item>
-          <template #label>树父编码字段
-            <el-tooltip content="树显示的父编码字段名， 如：parent_Id" placement="top">
+          <template #label>{{ $t('devTools.genInfoForm.treeParentCode') }}
+            <el-tooltip :content="$t('devTools.genInfoForm.treeParentCodeTip')" placement="top">
               <i class="ri-question-line" />
             </el-tooltip></template>
-          <el-select v-model="model.treeParentCode" placeholder="请选择">
+          <el-select
+            v-model="model.treeParentCode"
+            :placeholder="$t('devTools.genInfoForm.selectPlaceholder')"
+          >
             <el-option
               v-for="column in columns"
               :key="column.columnName"
@@ -142,11 +148,14 @@
       </el-col>
       <el-col :span="12">
         <el-form-item>
-          <template #label>树名称字段
-            <el-tooltip content="树节点的显示名称字段名， 如：dept_name" placement="top">
+          <template #label>{{ $t('devTools.genInfoForm.treeName') }}
+            <el-tooltip :content="$t('devTools.genInfoForm.treeNameTip')" placement="top">
               <i class="ri-question-line" />
             </el-tooltip></template>
-          <el-select v-model="model.treeName" placeholder="请选择">
+          <el-select
+            v-model="model.treeName"
+            :placeholder="$t('devTools.genInfoForm.selectPlaceholder')"
+          >
             <el-option
               v-for="column in columns"
               :key="column.columnName"
@@ -161,11 +170,17 @@
 </template>
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { FormInstance, FormRules } from 'element-plus'
 import type { GenTable } from '@/api/tools/gen'
 
-/** The 生成信息 tab. Same contract as BasicInfoForm; see it for the why. */
+/**
+ * The Generation Information tab. Same contract as BasicInfoForm; see it for
+ * the why, including why `rules` is a computed.
+ */
 defineOptions({ name: 'GenInfoForm' })
+
+const { t } = useI18n()
 
 const model = defineModel<GenTable>({ required: true })
 
@@ -176,22 +191,38 @@ const columns = computed(
   () => (model.value.columns ?? []) as Array<{ columnName?: string, columnComment?: string }>
 )
 
-const rules: FormRules = {
-  tplCategory: [{ required: true, message: '请选择生成模板', trigger: 'change' }],
+const rules = computed<FormRules>(() => ({
+  tplCategory: [
+    { required: true, message: t('devTools.genInfoForm.rules.tplCategory'), trigger: 'change' }
+  ],
   packageName: [
-    { required: true, message: '请输入生成包路径', trigger: 'blur' },
-    { pattern: /^[a-z]*$/, trigger: 'blur', message: '只允许小写字母，例如 system' }
+    { required: true, message: t('devTools.genInfoForm.rules.packageName'), trigger: 'blur' },
+    {
+      pattern: /^[a-z]*$/,
+      trigger: 'blur',
+      message: t('devTools.genInfoForm.rules.packageNamePattern')
+    }
   ],
   moduleName: [
-    { required: true, message: '请输入生成模块名', trigger: 'blur' },
-    { pattern: /^[a-z-]*[a-z]$/, trigger: 'blur', message: '只允许小写字母，例如 sys-demo' }
+    { required: true, message: t('devTools.genInfoForm.rules.moduleName'), trigger: 'blur' },
+    {
+      pattern: /^[a-z-]*[a-z]$/,
+      trigger: 'blur',
+      message: t('devTools.genInfoForm.rules.moduleNamePattern')
+    }
   ],
   businessName: [
-    { required: true, message: '请输入生成业务名', trigger: 'blur' },
-    { pattern: /^[a-z][A-Za-z]+$/, trigger: 'blur', message: '字母开头，只允许 a-z 与 A-Z' }
+    { required: true, message: t('devTools.genInfoForm.rules.businessName'), trigger: 'blur' },
+    {
+      pattern: /^[a-z][A-Za-z]+$/,
+      trigger: 'blur',
+      message: t('devTools.genInfoForm.rules.businessNamePattern')
+    }
   ],
-  functionName: [{ required: true, message: '请输入生成功能名', trigger: 'blur' }]
-}
+  functionName: [
+    { required: true, message: t('devTools.genInfoForm.rules.functionName'), trigger: 'blur' }
+  ]
+}))
 
 defineExpose({ validate: () => formRef.value?.validate().catch(() => false) })
 </script>

--- a/src/views/dev-tools/gen/index.vue
+++ b/src/views/dev-tools/gen/index.vue
@@ -2,29 +2,54 @@
   <PageContainer>
     <ProTable :table="table" selection row-key="tableId" :actions-width="170">
       <template #search>
-        <el-form-item label="表名称">
-          <el-input v-model="table.query.tableName" placeholder="请输入表名称" clearable style="width: 170px" />
+        <el-form-item :label="$t('devTools.gen.tableName')">
+          <el-input
+            v-model="table.query.tableName"
+            :placeholder="$t('devTools.gen.tableNamePlaceholder')"
+            clearable
+            style="width: 170px"
+          />
         </el-form-item>
-        <el-form-item label="菜单名称">
-          <el-input v-model="table.query.tableComment" placeholder="请输入菜单名称" clearable style="width: 170px" />
+        <el-form-item :label="$t('devTools.gen.tableComment')">
+          <el-input
+            v-model="table.query.tableComment"
+            :placeholder="$t('devTools.gen.tableCommentPlaceholder')"
+            clearable
+            style="width: 170px"
+          />
         </el-form-item>
       </template>
 
       <template #toolbar>
-        <el-button type="primary" @click="importVisible = true">导入</el-button>
+        <el-button type="primary" @click="importVisible = true">{{ $t('devTools.gen.import') }}</el-button>
         <el-button
           type="danger"
           plain
           :disabled="table.multiple"
           @click="remove(table.selectedIds)"
-        >删除</el-button>
+        >{{ $t('common.delete') }}</el-button>
       </template>
 
-      <el-table-column label="序号" prop="tableId" width="70" />
-      <el-table-column label="表名称" prop="tableName" min-width="150" show-overflow-tooltip />
-      <el-table-column label="菜单名称" prop="tableComment" min-width="150" show-overflow-tooltip />
-      <el-table-column label="模型名称" prop="className" min-width="150" show-overflow-tooltip />
-      <el-table-column label="创建时间" prop="createdAt" min-width="110">
+      <el-table-column :label="$t('devTools.gen.tableId')" prop="tableId" width="70" />
+      <el-table-column
+        :label="$t('devTools.gen.tableName')"
+        prop="tableName"
+        min-width="150"
+        show-overflow-tooltip
+      />
+      <el-table-column
+        :label="$t('devTools.gen.tableComment')"
+        prop="tableComment"
+        min-width="150"
+        show-overflow-tooltip
+      />
+      <el-table-column
+        :label="$t('devTools.gen.className')"
+        prop="className"
+        min-width="150"
+        show-overflow-tooltip
+      />
+      <el-table-column :label="$t('common.createdAt')" prop="createdAt" min-width="110">
         <template #default="{ row }"><DateCell :value="row.createdAt" /></template>
       </el-table-column>
 
@@ -35,18 +60,18 @@
         the rest behind a menu.
       -->
       <template #actions="{ row }">
-        <el-button link type="primary" @click="edit(row)">编辑</el-button>
-        <el-button link type="primary" @click="preview(row)">预览</el-button>
+        <el-button link type="primary" @click="edit(row)">{{ $t('devTools.gen.edit') }}</el-button>
+        <el-button link type="primary" @click="preview(row)">{{ $t('devTools.gen.preview') }}</el-button>
         <el-dropdown trigger="click" @command="(command: Command) => run(command, row)">
-          <el-button link type="primary" class="row-icon-action" title="更多操作">
+          <el-button link type="primary" class="row-icon-action" :title="$t('devTools.gen.moreActions')">
             <el-icon><MoreFilled /></el-icon>
           </el-button>
           <template #dropdown>
             <el-dropdown-menu>
-              <el-dropdown-item command="project">生成到项目</el-dropdown-item>
-              <el-dropdown-item command="db">生成配置</el-dropdown-item>
-              <el-dropdown-item command="api">生成迁移脚本</el-dropdown-item>
-              <el-dropdown-item command="delete" divided>删除</el-dropdown-item>
+              <el-dropdown-item command="project">{{ $t('devTools.gen.generateToProject') }}</el-dropdown-item>
+              <el-dropdown-item command="db">{{ $t('devTools.gen.generateConfig') }}</el-dropdown-item>
+              <el-dropdown-item command="api">{{ $t('devTools.gen.generateMigration') }}</el-dropdown-item>
+              <el-dropdown-item command="delete" divided>{{ $t('common.delete') }}</el-dropdown-item>
             </el-dropdown-menu>
           </template>
         </el-dropdown>
@@ -56,9 +81,14 @@
     <!--
       v-model binds `previewOpen`. It used to bind `open`, which no data property
       ever declared, so Vue warned on every render and the dialog never appeared:
-      clicking 预览 fetched every template and showed none of them.
+      clicking Preview fetched every template and showed none of them.
     -->
-    <el-dialog v-model="previewOpen" title="代码预览" fullscreen :close-on-click-modal="false">
+    <el-dialog
+      v-model="previewOpen"
+      :title="$t('devTools.gen.previewTitle')"
+      fullscreen
+      :close-on-click-modal="false"
+    >
       <div class="gen-preview">
         <div class="gen-preview__tabs">
           <el-tag
@@ -84,6 +114,7 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { Codemirror } from 'vue-codemirror'
 import { MoreFilled } from '@element-plus/icons-vue'
@@ -103,6 +134,7 @@ import type { SysTables, GenTableQuery } from '@/api/tools/gen'
 // Must match the menu_name the backend serves, or keep-alive silently misses
 defineOptions({ name: 'Gen' })
 
+const { t } = useI18n()
 const router = useRouter()
 
 const table = useTable<SysTables, GenTableQuery>({
@@ -113,7 +145,9 @@ const table = useTable<SysTables, GenTableQuery>({
 
 const { remove } = useRemove({
   api: delTable,
-  confirmText: count => `确认删除选中的 ${count} 张表的生成配置？`,
+  // A function, so the sentence is built when the dialog opens rather than when
+  // the page was set up -- the language may have changed in between
+  confirmText: count => t('devTools.gen.deleteConfirm', { count }, count),
   onSuccess: () => table.getList()
 })
 
@@ -166,7 +200,7 @@ const run = async(command: Command, row: SysTables) => {
   generating = true
   try {
     const response = await GENERATORS[command](Number(row.tableId))
-    msgSuccess(response.msg || '已生成')
+    msgSuccess(response.msg || t('devTools.gen.generated'))
   } catch {
     // Reported by the interceptor
   } finally {

--- a/src/views/profile/index.vue
+++ b/src/views/profile/index.vue
@@ -6,7 +6,7 @@
           <el-card class="box-card">
             <template #header>
               <div class="clearfix">
-                <span>个人信息</span>
+                <span>{{ $t('profile.title') }}</span>
               </div>
             </template>
             <div>
@@ -15,27 +15,27 @@
               </div>
               <ul class="list-group list-group-striped">
                 <li class="list-group-item">
-                  <svg-icon icon-class="user" />用户名称
+                  <svg-icon icon-class="user" />{{ $t('profile.username') }}
                   <div class="pull-right">{{ user.username }}</div>
                 </li>
                 <li class="list-group-item">
-                  <svg-icon icon-class="phone" />手机号码
+                  <svg-icon icon-class="phone" />{{ $t('profile.phone') }}
                   <div class="pull-right">{{ user.phone }}</div>
                 </li>
                 <li class="list-group-item">
-                  <svg-icon icon-class="email" />用户邮箱
+                  <svg-icon icon-class="email" />{{ $t('profile.email') }}
                   <div class="pull-right">{{ user.email }}</div>
                 </li>
                 <li class="list-group-item">
-                  <svg-icon icon-class="tree" />所属部门
+                  <svg-icon icon-class="tree" />{{ $t('profile.dept') }}
                   <div class="pull-right">{{ deptName }}</div>
                 </li>
                 <li class="list-group-item">
-                  <svg-icon icon-class="peoples" />所属角色
+                  <svg-icon icon-class="peoples" />{{ $t('profile.role') }}
                   <div class="pull-right">{{ roleName }}</div>
                 </li>
                 <li class="list-group-item">
-                  <svg-icon icon-class="date" />创建日期
+                  <svg-icon icon-class="date" />{{ $t('profile.createdAt') }}
                   <div class="pull-right">{{ user.createdAt }}</div>
                 </li>
               </ul>
@@ -46,14 +46,14 @@
           <el-card>
             <template #header>
               <div class="clearfix">
-                <span>基本资料</span>
+                <span>{{ $t('profile.basic') }}</span>
               </div>
             </template>
             <el-tabs v-model="activeTab">
-              <el-tab-pane label="基本资料" name="userinfo">
+              <el-tab-pane :label="$t('profile.tabs.info')" name="userinfo">
                 <userInfo :user="user" />
               </el-tab-pane>
-              <el-tab-pane label="修改密码" name="resetPwd">
+              <el-tab-pane :label="$t('profile.tabs.password')" name="resetPwd">
                 <resetPwd :user="user" />
               </el-tab-pane>
             </el-tabs>
@@ -105,7 +105,7 @@ export default {
             }
           }
         } else {
-          this.roleName = '暂无'
+          this.roleName = this.$t('profile.noRole')
         }
         this.dept = response.data.user.dept
         this.deptName = this.dept.deptName

--- a/src/views/profile/resetPwd.vue
+++ b/src/views/profile/resetPwd.vue
@@ -1,17 +1,17 @@
 <template>
   <el-form ref="form" :model="user" :rules="rules" label-width="80px">
-    <el-form-item label="旧密码" prop="oldPassword">
-      <el-input v-model="user.oldPassword" placeholder="请输入旧密码" type="password" />
+    <el-form-item :label="$t('profile.password.old')" prop="oldPassword">
+      <el-input v-model="user.oldPassword" :placeholder="$t('profile.password.oldPlaceholder')" type="password" />
     </el-form-item>
-    <el-form-item label="新密码" prop="newPassword">
-      <el-input v-model="user.newPassword" placeholder="请输入新密码" type="password" />
+    <el-form-item :label="$t('profile.password.new')" prop="newPassword">
+      <el-input v-model="user.newPassword" :placeholder="$t('profile.password.newPlaceholder')" type="password" />
     </el-form-item>
-    <el-form-item label="确认密码" prop="confirmPassword">
-      <el-input v-model="user.confirmPassword" placeholder="请确认密码" type="password" />
+    <el-form-item :label="$t('profile.password.confirm')" prop="confirmPassword">
+      <el-input v-model="user.confirmPassword" :placeholder="$t('profile.password.confirmPlaceholder')" type="password" />
     </el-form-item>
     <el-form-item>
-      <el-button type="primary" size="mini" @click="submit">保存</el-button>
-      <el-button type="danger" size="mini" @click="close">关闭</el-button>
+      <el-button type="primary" size="mini" @click="submit">{{ $t('profile.save') }}</el-button>
+      <el-button type="danger" size="mini" @click="close">{{ $t('profile.close') }}</el-button>
     </el-form-item>
   </el-form>
 </template>
@@ -22,31 +22,45 @@ import { updateUserPwd } from '@/api/admin/sys-user'
 
 export default {
   data() {
-    const equalToPassword = (rule, value, callback) => {
-      if (this.user.newPassword !== value) {
-        callback(new Error('两次输入的密码不一致'))
-      } else {
-        callback()
-      }
-    }
     return {
       test: '1test',
       user: {
         oldPassword: undefined,
         newPassword: undefined,
         confirmPassword: undefined
-      },
-      // 表单校验
-      rules: {
+      }
+    }
+  },
+  computed: {
+    /**
+     * Rebuilt per render rather than held in data().
+     *
+     * data() runs once, so messages built from t() there would keep whichever
+     * language the page was opened in -- including the one already displayed
+     * under a field. el-form revalidates when its rules change, which is what
+     * repaints a message that is on screen.
+     *
+     * The validator is a different case: it is called at validation time, so
+     * the Error it raises is already resolved then.
+     */
+    rules() {
+      const equalToPassword = (rule, value, callback) => {
+        if (this.user.newPassword !== value) {
+          callback(new Error(this.$t('profile.password.rules.mismatch')))
+        } else {
+          callback()
+        }
+      }
+      return {
         oldPassword: [
-          { required: true, message: '旧密码不能为空', trigger: 'blur' }
+          { required: true, message: this.$t('profile.password.rules.oldRequired'), trigger: 'blur' }
         ],
         newPassword: [
-          { required: true, message: '新密码不能为空', trigger: 'blur' },
-          { min: 6, max: 20, message: '长度在 6 到 20 个字符', trigger: 'blur' }
+          { required: true, message: this.$t('profile.password.rules.newRequired'), trigger: 'blur' },
+          { min: 6, max: 20, message: this.$t('profile.password.rules.length'), trigger: 'blur' }
         ],
         confirmPassword: [
-          { required: true, message: '确认密码不能为空', trigger: 'blur' },
+          { required: true, message: this.$t('profile.password.rules.confirmRequired'), trigger: 'blur' },
           { required: true, validator: equalToPassword, trigger: 'blur' }
         ]
       }

--- a/src/views/profile/userAvatar.vue
+++ b/src/views/profile/userAvatar.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <img :src="options.img" title="点击上传头像" class="img-circle img-lg" @click="editCropper()">
+    <img :src="options.img" :title="$t('profile.avatar.hint')" class="img-circle img-lg" @click="editCropper()">
     <el-dialog v-model="open" :title="title" width="800px" :close-on-click-modal="false">
       <el-row>
         <el-col :xs="24" :md="12" :style="{height: '350px'}">
@@ -26,7 +26,7 @@
         <el-col :lg="2" :md="2">
           <el-upload action="#" :http-request="requestUpload" :show-file-list="false" :before-upload="beforeUpload">
             <el-button size="small">
-              上传
+              {{ $t('profile.avatar.upload') }}
               <i class="ri-upload-line el-icon--right" />
             </el-button>
           </el-upload>
@@ -44,7 +44,7 @@
           <el-button size="small" @click="rotateRight()" />
         </el-col>
         <el-col :lg="{span: 2, offset: 6}" :md="2">
-          <el-button type="primary" size="small" @click="uploadImg()">提 交</el-button>
+          <el-button type="primary" size="small" @click="uploadImg()">{{ $t('profile.avatar.submit') }}</el-button>
         </el-col>
       </el-row>
     </el-dialog>
@@ -66,8 +66,6 @@ export default {
     return {
       // 是否显示弹出层
       open: false,
-      // 弹出层标题
-      title: '修改头像',
       options: {
         img: useUserStore().avatar, // 裁剪图片的地址
         autoCrop: true, // 是否默认生成截图框
@@ -76,6 +74,16 @@ export default {
         fixedBox: true // 固定截图框大小 不允许改变
       },
       previews: {}
+    }
+  },
+  computed: {
+    /**
+     * The dialog title, which used to live in data(). That runs once, so a
+     * title built from t() there would keep the language the page was opened
+     * in -- and this dialog is opened long after that.
+     */
+    title() {
+      return this.$t('profile.avatar.dialogTitle')
     }
   },
   methods: {
@@ -102,7 +110,7 @@ export default {
     // 上传预处理
     beforeUpload(file) {
       if (file.type.indexOf('image/') === -1) {
-        this.msgError('文件格式错误，请上传图片类型,如：JPG，PNG后缀的文件。')
+        this.msgError(this.$t('profile.avatar.wrongType'))
       } else {
         const reader = new FileReader()
         reader.readAsDataURL(file)

--- a/src/views/profile/userInfo.vue
+++ b/src/views/profile/userInfo.vue
@@ -1,23 +1,23 @@
 <template>
   <el-form ref="form" :model="userForm" :rules="rules" label-width="80px">
-    <el-form-item label="用户昵称" prop="nickName">
+    <el-form-item :label="$t('profile.info.nickName')" prop="nickName">
       <el-input v-model="userForm.nickName" />
     </el-form-item>
-    <el-form-item label="手机号码" prop="phone">
+    <el-form-item :label="$t('profile.info.phone')" prop="phone">
       <el-input v-model="userForm.phone" maxlength="11" />
     </el-form-item>
-    <el-form-item label="邮箱" prop="email">
+    <el-form-item :label="$t('profile.info.email')" prop="email">
       <el-input v-model="userForm.email" maxlength="50" />
     </el-form-item>
-    <el-form-item label="性别">
+    <el-form-item :label="$t('profile.info.sex')">
       <el-radio-group v-model="userForm.sex">
-        <el-radio label="0">男</el-radio>
-        <el-radio label="1">女</el-radio>
+        <el-radio label="0">{{ $t('profile.info.male') }}</el-radio>
+        <el-radio label="1">{{ $t('profile.info.female') }}</el-radio>
       </el-radio-group>
     </el-form-item>
     <el-form-item>
-      <el-button type="primary" size="mini" @click="submit">保存</el-button>
-      <el-button type="danger" size="mini" @click="close">关闭</el-button>
+      <el-button type="primary" size="mini" @click="submit">{{ $t('profile.save') }}</el-button>
+      <el-button type="danger" size="mini" @click="close">{{ $t('profile.close') }}</el-button>
     </el-form-item>
   </el-form>
 </template>
@@ -33,25 +33,33 @@ export default {
   },
   data() {
     return {
-      userForm: { ...this.user },
-      // 表单校验
-      rules: {
+      userForm: { ...this.user }
+    }
+  },
+  computed: {
+    /**
+     * Rebuilt per render rather than held in data(), which runs once: a message
+     * built from t() there keeps whichever language the page was opened in,
+     * including one already displayed under a field.
+     */
+    rules() {
+      return {
         nickName: [
-          { required: true, message: '用户昵称不能为空', trigger: 'blur' }
+          { required: true, message: this.$t('profile.info.rules.nickName'), trigger: 'blur' }
         ],
         email: [
-          { required: true, message: '邮箱地址不能为空', trigger: 'blur' },
+          { required: true, message: this.$t('profile.info.rules.emailRequired'), trigger: 'blur' },
           {
             type: 'email',
-            message: "'请输入正确的邮箱地址",
+            message: this.$t('profile.info.rules.emailFormat'),
             trigger: ['blur', 'change']
           }
         ],
         phone: [
-          { required: true, message: '手机号码不能为空', trigger: 'blur' },
+          { required: true, message: this.$t('profile.info.rules.phoneRequired'), trigger: 'blur' },
           {
             pattern: /^1[3|4|5|6|7|8|9][0-9]\d{8}$/,
-            message: '请输入正确的手机号码',
+            message: this.$t('profile.info.rules.phoneFormat'),
             trigger: 'blur'
           }
         ]

--- a/src/views/schedule/index.vue
+++ b/src/views/schedule/index.vue
@@ -2,51 +2,88 @@
   <PageContainer>
     <ProTable :table="table" selection row-key="jobId" :actions-width="150">
       <template #search>
-        <el-form-item label="名称">
-          <el-input v-model="table.query.jobName" placeholder="请输入名称" clearable style="width: 160px" />
+        <el-form-item :label="$t('schedule.name')">
+          <el-input
+            v-model="table.query.jobName"
+            :placeholder="$t('schedule.namePlaceholder')"
+            clearable
+            style="width: 160px"
+          />
         </el-form-item>
-        <el-form-item label="任务分组">
-          <el-select v-model="table.query.jobGroup" placeholder="任务分组" clearable style="width: 130px">
+        <el-form-item :label="$t('schedule.jobGroup')">
+          <el-select
+            v-model="table.query.jobGroup"
+            :placeholder="$t('schedule.jobGroup')"
+            clearable
+            style="width: 130px"
+          >
             <el-option v-for="item in sys_job_group" :key="item.value" :label="item.label" :value="item.value" />
           </el-select>
         </el-form-item>
-        <el-form-item label="状态">
-          <el-select v-model="table.query.status" placeholder="任务状态" clearable style="width: 130px">
+        <el-form-item :label="$t('schedule.status')">
+          <el-select
+            v-model="table.query.status"
+            :placeholder="$t('schedule.statusPlaceholder')"
+            clearable
+            style="width: 130px"
+          >
             <el-option v-for="item in sys_job_status" :key="item.value" :label="item.label" :value="item.value" />
           </el-select>
         </el-form-item>
       </template>
 
       <template #toolbar>
-        <el-button v-permisaction="['job:sysJob:add']" type="primary" @click="form.openCreate()">新增</el-button>
+        <el-button v-permisaction="['job:sysJob:add']" type="primary" @click="form.openCreate()">
+          {{ $t('common.add') }}
+        </el-button>
         <el-button
           v-permisaction="['job:sysJob:remove']"
           type="danger"
           plain
           :disabled="table.multiple"
           @click="remove(table.selectedIds)"
-        >删除</el-button>
-        <el-button v-permisaction="['job:sysJob:log']" @click="openLog">日志</el-button>
+        >{{ $t('common.delete') }}</el-button>
+        <el-button v-permisaction="['job:sysJob:log']" @click="openLog">{{ $t('schedule.log') }}</el-button>
       </template>
 
-      <el-table-column label="编码" prop="jobId" width="80" />
-      <el-table-column label="名称" prop="jobName" min-width="140" show-overflow-tooltip />
-      <el-table-column label="分组" prop="jobGroup" width="90">
+      <el-table-column :label="$t('schedule.jobId')" prop="jobId" width="80" />
+      <el-table-column :label="$t('schedule.name')" prop="jobName" min-width="140" show-overflow-tooltip />
+      <el-table-column :label="$t('schedule.group')" prop="jobGroup" width="90">
         <template #default="{ row }">{{ dictLabel(sys_job_group, row.jobGroup) }}</template>
       </el-table-column>
-      <el-table-column label="cron 表达式" prop="cronExpression" min-width="140" show-overflow-tooltip />
-      <el-table-column label="调用目标" prop="invokeTarget" min-width="180" show-overflow-tooltip>
+      <el-table-column
+        :label="$t('schedule.cronExpression')"
+        prop="cronExpression"
+        min-width="140"
+        show-overflow-tooltip
+      />
+      <el-table-column
+        :label="$t('schedule.invokeTarget')"
+        prop="invokeTarget"
+        min-width="180"
+        show-overflow-tooltip
+      >
         <template #default="{ row }">
           <el-popover trigger="hover" placement="top" :width="320">
-            <p class="peek-line">参数：{{ row.args || '无' }}</p>
-            <p class="peek-line">调用类型：{{ Number(row.jobType) === 1 ? '接口' : '函数' }}</p>
-            <p class="peek-line">执行策略：{{ MISFIRE[Number(row.misfirePolicy)] ?? '-' }}</p>
-            <p class="peek-line">并发：{{ Number(row.concurrent) === 0 ? '允许' : '禁止' }}</p>
+            <p class="peek-line">{{ $t('schedule.peekArgs', { value: row.args || $t('schedule.none') }) }}</p>
+            <p class="peek-line">
+              {{ $t('schedule.peekJobType', {
+                value: Number(row.jobType) === 1 ? $t('schedule.jobTypeApi') : $t('schedule.jobTypeFunc')
+              }) }}
+            </p>
+            <p class="peek-line">
+              {{ $t('schedule.peekMisfire', { value: MISFIRE[Number(row.misfirePolicy)] ?? '-' }) }}
+            </p>
+            <p class="peek-line">
+              {{ $t('schedule.peekConcurrent', {
+                value: Number(row.concurrent) === 0 ? $t('schedule.allow') : $t('schedule.forbid')
+              }) }}
+            </p>
             <template #reference><span>{{ row.invokeTarget }}</span></template>
           </el-popover>
         </template>
       </el-table-column>
-      <el-table-column label="状态" prop="status" width="90">
+      <el-table-column :label="$t('schedule.status')" prop="status" width="90">
         <template #default="{ row }">
           <el-tag :type="Number(row.status) === 2 ? 'success' : 'danger'" disable-transitions>
             {{ dictLabel(sys_job_status, String(row.status)) }}
@@ -56,7 +93,7 @@
 
       <template #actions="{ row }">
         <el-button v-permisaction="['job:sysJob:edit']" link type="primary" @click="form.openEdit(row)">
-          修改
+          {{ $t('common.edit') }}
         </el-button>
         <!--
           entry_id is the handle cron gives a scheduled job, so zero means it is
@@ -69,21 +106,21 @@
           link
           type="primary"
           @click="toggle(row, 'stop')"
-        >停止</el-button>
+        >{{ $t('schedule.stop') }}</el-button>
         <el-button
           v-else-if="Number(row.entry_id) === 0 && Number(row.status) !== 1"
           v-permisaction="['job:sysJob:start']"
           link
           type="primary"
           @click="toggle(row, 'start')"
-        >启动</el-button>
+        >{{ $t('schedule.start') }}</el-button>
         <!-- Icon rather than the words, per the two-button rule -->
         <el-button
           v-permisaction="['job:sysJob:remove']"
           link
           type="danger"
           class="row-icon-action"
-          :title="`删除任务：${row.jobName}`"
+          :title="$t('schedule.deleteTitle', { name: row.jobName })"
           @click="remove(row.jobId)"
         >
           <el-icon><Delete /></el-icon>
@@ -95,13 +132,17 @@
       <el-form :ref="form.bindFormRef" :model="form.model" :rules="form.rules" label-width="120px">
         <el-row :gutter="16">
           <el-col :span="12">
-            <el-form-item label="名称" prop="jobName">
-              <el-input v-model="form.model.jobName" placeholder="名称" />
+            <el-form-item :label="$t('schedule.name')" prop="jobName">
+              <el-input v-model="form.model.jobName" :placeholder="$t('schedule.name')" />
             </el-form-item>
           </el-col>
           <el-col :span="12">
-            <el-form-item label="任务分组" prop="jobGroup">
-              <el-select v-model="form.model.jobGroup" placeholder="请选择" style="width: 100%">
+            <el-form-item :label="$t('schedule.jobGroup')" prop="jobGroup">
+              <el-select
+                v-model="form.model.jobGroup"
+                :placeholder="$t('schedule.selectPlaceholder')"
+                style="width: 100%"
+              >
                 <el-option v-for="item in sys_job_group" :key="item.value" :label="item.label" :value="item.value" />
               </el-select>
             </el-form-item>
@@ -110,54 +151,58 @@
             <el-form-item prop="invokeTarget">
               <template #label>
                 <FieldLabel
-                  label="调用目标"
-                  tip="调用示例：func (t *EXEC) ExamplesNoParam(){..} 填写 ExamplesNoParam 即可；目前不支持带参调用"
+                  :label="$t('schedule.invokeTarget')"
+                  :tip="$t('schedule.invokeTargetTip')"
                 />
               </template>
-              <el-input v-model="form.model.invokeTarget" placeholder="调用目标" />
+              <el-input v-model="form.model.invokeTarget" :placeholder="$t('schedule.invokeTarget')" />
             </el-form-item>
           </el-col>
           <el-col :span="24">
             <el-form-item prop="args">
               <template #label>
                 <FieldLabel
-                  label="目标参数"
-                  tip="有参：请以 string 格式填写；无参：留空。目前仅支持函数调用"
+                  :label="$t('schedule.args')"
+                  :tip="$t('schedule.argsTip')"
                 />
               </template>
-              <el-input v-model="form.model.args" placeholder="目标参数" />
+              <el-input v-model="form.model.args" :placeholder="$t('schedule.args')" />
             </el-form-item>
           </el-col>
           <el-col :span="12">
-            <el-form-item label="cron 表达式" prop="cronExpression">
-              <el-input v-model="form.model.cronExpression" placeholder="cron 表达式" />
+            <el-form-item :label="$t('schedule.cronExpression')" prop="cronExpression">
+              <el-input v-model="form.model.cronExpression" :placeholder="$t('schedule.cronExpression')" />
             </el-form-item>
           </el-col>
           <el-col :span="12">
-            <el-form-item label="是否并发" prop="concurrent">
+            <el-form-item :label="$t('schedule.concurrent')" prop="concurrent">
               <el-radio-group v-model="form.model.concurrent">
-                <el-radio-button :value="0">允许</el-radio-button>
-                <el-radio-button :value="1">禁止</el-radio-button>
+                <el-radio-button :value="0">{{ $t('schedule.allow') }}</el-radio-button>
+                <el-radio-button :value="1">{{ $t('schedule.forbid') }}</el-radio-button>
               </el-radio-group>
             </el-form-item>
           </el-col>
           <el-col :span="12">
-            <el-form-item label="调用类型" prop="jobType">
+            <el-form-item :label="$t('schedule.jobType')" prop="jobType">
               <el-radio-group v-model="form.model.jobType">
-                <el-radio-button :value="1">接口</el-radio-button>
-                <el-radio-button :value="2">函数</el-radio-button>
+                <el-radio-button :value="1">{{ $t('schedule.jobTypeApi') }}</el-radio-button>
+                <el-radio-button :value="2">{{ $t('schedule.jobTypeFunc') }}</el-radio-button>
               </el-radio-group>
             </el-form-item>
           </el-col>
           <el-col :span="12">
-            <el-form-item label="状态" prop="status">
-              <el-select v-model="form.model.status" placeholder="请选择" style="width: 100%">
+            <el-form-item :label="$t('schedule.status')" prop="status">
+              <el-select
+                v-model="form.model.status"
+                :placeholder="$t('schedule.selectPlaceholder')"
+                style="width: 100%"
+              >
                 <el-option v-for="item in sys_job_status" :key="item.value" :label="item.label" :value="item.value" />
               </el-select>
             </el-form-item>
           </el-col>
           <el-col :span="24">
-            <el-form-item label="执行策略" prop="misfirePolicy">
+            <el-form-item :label="$t('schedule.misfirePolicy')" prop="misfirePolicy">
               <el-radio-group v-model="form.model.misfirePolicy">
                 <el-radio-button v-for="(label, value) in MISFIRE" :key="value" :value="Number(value)">
                   {{ label }}
@@ -168,14 +213,18 @@
         </el-row>
       </el-form>
       <template #footer>
-        <el-button @click="form.close()">取 消</el-button>
-        <el-button type="primary" :loading="form.submitting" @click="form.submit()">确 定</el-button>
+        <el-button @click="form.close()">{{ $t('common.dialogCancel') }}</el-button>
+        <el-button type="primary" :loading="form.submitting" @click="form.submit()">
+          {{ $t('common.dialogConfirm') }}
+        </el-button>
       </template>
     </el-dialog>
   </PageContainer>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { ElMessageBox } from 'element-plus'
 import { Delete } from '@element-plus/icons-vue'
@@ -196,11 +245,22 @@ import type { SysJob, SysJobQuery } from '@/types/admin'
 // Must match the menu_name the backend serves, or keep-alive silently misses
 defineOptions({ name: 'ScheduleManage' })
 
+const { t } = useI18n()
 const router = useRouter()
 const { sys_job_group, sys_job_status } = useDict('sys_job_group', 'sys_job_status')
 
-/** What the scheduler does with a run it missed. */
-const MISFIRE: Record<number, string> = { 1: '立即执行', 2: '执行一次', 3: '放弃执行' }
+/**
+ * What the scheduler does with a run it missed.
+ *
+ * Computed, not a plain object: the radio group and the hover card both read it
+ * on every render, and a table already on screen has to follow a language
+ * change without refetching.
+ */
+const MISFIRE = computed<Record<number, string>>(() => ({
+  1: t('schedule.misfire.immediate'),
+  2: t('schedule.misfire.once'),
+  3: t('schedule.misfire.skip')
+}))
 
 const table = useTable<SysJob, SysJobQuery>({
   api: listSysJob,
@@ -208,12 +268,20 @@ const table = useTable<SysJob, SysJobQuery>({
   defaultQuery: () => ({ jobName: undefined, jobGroup: undefined, status: undefined })
 })
 
-const rules: FormRules = {
-  jobName: [{ required: true, message: '名称不能为空', trigger: 'blur' }],
-  jobGroup: [{ required: true, message: '任务分组不能为空', trigger: 'change' }],
-  invokeTarget: [{ required: true, message: '调用目标不能为空', trigger: 'blur' }],
-  cronExpression: [{ required: true, message: 'cron 表达式不能为空', trigger: 'blur' }]
-}
+/**
+ * Rebuilt whenever the language changes.
+ *
+ * A plain object is evaluated once, at setup, so a message already rendered
+ * under a field would keep the language the page was opened in -- and this page
+ * is kept alive, so reopening the dialog does not re-run setup. useForm unwraps
+ * the ref, so :rules="form.rules" is unchanged.
+ */
+const rules = computed<FormRules>(() => ({
+  jobName: [{ required: true, message: t('schedule.rules.jobName'), trigger: 'blur' }],
+  jobGroup: [{ required: true, message: t('schedule.rules.jobGroup'), trigger: 'change' }],
+  invokeTarget: [{ required: true, message: t('schedule.rules.invokeTarget'), trigger: 'blur' }],
+  cronExpression: [{ required: true, message: t('schedule.rules.cronExpression'), trigger: 'blur' }]
+}))
 
 const form = useForm<SysJob, number>({
   defaultModel: () => ({
@@ -230,14 +298,21 @@ const form = useForm<SysJob, number>({
   }),
   idKey: 'jobId',
   rules,
-  title: { create: '添加任务', edit: '修改任务' },
+  // Computed, not `t(...)` directly: useForm reads the option on every render,
+  // so a string resolved here once would pin the dialog to the language the
+  // page was opened in.
+  title: {
+    create: computed(() => t('schedule.addTitle')),
+    edit: computed(() => t('schedule.editTitle'))
+  },
   api: { get: getSysJobForForm, add: addSysJob, update: updateSysJob },
   onSuccess: () => table.getList()
 })
 
 const { remove } = useRemove({
   api: delSysJob,
-  confirmText: count => `确认删除选中的 ${count} 个任务？`,
+  // A function, so the sentence is built when the dialog opens
+  confirmText: count => t('schedule.deleteConfirm', { count }, count),
   onSuccess: () => table.getList()
 })
 
@@ -254,12 +329,18 @@ let pending = false
 const toggle = async(row: SysJob, action: 'start' | 'stop') => {
   if (pending) return
   pending = true
-  const verb = action === 'start' ? '启动' : '停止'
+  // Two whole sentences rather than one with the verb interpolated. The verb
+  // sits mid-sentence in Chinese and at the front in English, so a shared
+  // template with a {verb} slot cannot be right in both. Both keys are spelled
+  // out so tests/unit/lang/usage.spec.ts can see them.
+  const question = action === 'start'
+    ? t('schedule.startConfirm', { name: row.jobName })
+    : t('schedule.stopConfirm', { name: row.jobName })
   try {
-    await ElMessageBox.confirm(`确认${verb}任务「${row.jobName}」？`, '提示', {
+    await ElMessageBox.confirm(question, t('common.notice'), {
       type: 'warning',
-      confirmButtonText: '确定',
-      cancelButtonText: '取消'
+      confirmButtonText: t('common.confirm'),
+      cancelButtonText: t('common.cancel')
     })
   } catch {
     pending = false
@@ -268,7 +349,8 @@ const toggle = async(row: SysJob, action: 'start' | 'stop') => {
   try {
     const call = action === 'start' ? startJob : removeJob
     const response = await call(row.jobId as number)
-    msgSuccess(response.msg || `${verb}成功`)
+    const done = action === 'start' ? t('schedule.startSuccess') : t('schedule.stopSuccess')
+    msgSuccess(response.msg || done)
     await table.getList()
   } catch {
     // Reported by the interceptor

--- a/src/views/schedule/log.vue
+++ b/src/views/schedule/log.vue
@@ -3,18 +3,24 @@
     <div class="job-log">
       <div class="job-log__bar">
         <span class="job-log__state" :class="`is-${state}`">
-          <i class="job-log__dot" />{{ STATE_LABEL[state] }}
+          <i class="job-log__dot" />{{ stateLabel }}
         </span>
-        <span class="job-log__count">{{ lines.length }} 行</span>
+        <span class="job-log__count">
+          {{ $t('schedule.jobLog.lines', { count: lines.length }, lines.length) }}
+        </span>
         <div class="job-log__actions">
-          <el-button :disabled="!lines.length" @click="lines = []">清空</el-button>
-          <el-button v-if="state === 'closed'" type="primary" @click="connect">重连</el-button>
+          <el-button :disabled="!lines.length" @click="lines = []">
+            {{ $t('schedule.jobLog.clear') }}
+          </el-button>
+          <el-button v-if="state === 'closed'" type="primary" @click="connect">
+            {{ $t('schedule.jobLog.reconnect') }}
+          </el-button>
         </div>
       </div>
 
       <div ref="viewport" class="job-log__viewport">
         <p v-if="!lines.length" class="job-log__empty">
-          {{ state === 'open' ? '已连接，等待任务输出…' : '未连接' }}
+          {{ state === 'open' ? $t('schedule.jobLog.waiting') : $t('schedule.jobLog.disconnected') }}
         </p>
         <!-- Newest last, so the stream reads the way a terminal does. The
              previous version unshifted, which put the newest line on top and
@@ -28,22 +34,30 @@
 </template>
 
 <script setup lang="ts">
-import { ref, nextTick, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, nextTick, onMounted, onBeforeUnmount } from 'vue'
+import { useI18n } from 'vue-i18n'
 import PageContainer from '@/components/PageContainer/index.vue'
 import { unWsLogout } from '@/api/ws'
 import { useUserStore } from '@/stores/user'
 
 defineOptions({ name: 'JobLog' })
 
+const { t } = useI18n()
+
 type State = 'connecting' | 'open' | 'closed'
 
-const STATE_LABEL: Record<State, string> = {
-  connecting: '连接中',
-  open: '已连接',
-  closed: '已断开'
-}
-
 const state = ref<State>('connecting')
+
+/**
+ * Computed, not a lookup table built once: this page is opened, left connected
+ * and looked at again later, so the word beside the dot has to follow a
+ * language change without a reconnect.
+ */
+const stateLabel = computed(() => ({
+  connecting: t('schedule.jobLog.connecting'),
+  open: t('schedule.jobLog.open'),
+  closed: t('schedule.jobLog.closed')
+}[state.value]))
 const lines = ref<Array<{ id: number, at: string, text: string }>>([])
 const viewport = ref<HTMLElement>()
 

--- a/src/views/sys-tools/monitor.vue
+++ b/src/views/sys-tools/monitor.vue
@@ -26,21 +26,21 @@
                 <div class="monitor-content">
                   <el-row :gutter="10">
                     <el-col :sm="24" :md="12">
-                      <Cell label="系统" :value="info.os.goOs" border />
-                      <Cell label="内存" :value="`${info.mem.used}MB/${info.mem.total}MB`" border />
-                      <Cell label="交换" :value="`${info.swap.used}/${info.swap.total}`" border />
+                      <Cell :label="$t('sysTools.monitor.system')" :value="info.os.goOs" border />
+                      <Cell :label="$t('sysTools.monitor.memory')" :value="`${info.mem.used}MB/${info.mem.total}MB`" border />
+                      <Cell :label="$t('sysTools.monitor.swap')" :value="`${info.swap.used}/${info.swap.total}`" border />
                     </el-col>
                     <el-col :sm="24" :md="12">
-                      <Cell label="时间" :value="info.os.time" border />
-                      <Cell label="在线" :value="`${info.bootTime}小时`" border />
-                      <Cell label="硬盘" :value="`${info.disk.used}GB/${info.disk.total}GB`" border />
+                      <Cell :label="$t('sysTools.monitor.time')" :value="info.os.time" border />
+                      <Cell :label="$t('sysTools.monitor.uptime')" :value="$t('sysTools.monitor.hours', { n: info.bootTime })" border />
+                      <Cell :label="$t('sysTools.monitor.disk')" :value="`${info.disk.used}GB/${info.disk.total}GB`" border />
                     </el-col>
                   </el-row>
                   <el-row :gutter="10">
                     <el-col :sm="12" :md="12" class="line">
                       <el-row>
                         <el-col span="12" :sm="8" :md="8" xs="12">
-                          下载<i class="ri-arrow-down-s-fill" />
+                          {{ $t('sysTools.monitor.download') }}<i class="ri-arrow-down-s-fill" />
                         </el-col>
                         <el-col span="12" :sm="16" :md="16" xs="12" class="line-value">
                           {{ info.net.in }}KB
@@ -50,7 +50,7 @@
                     <el-col :sm="12" :md="12" class="line">
                       <el-row border>
                         <el-col span="12" :sm="6" :md="8">
-                          上传<i class="ri-arrow-up-s-fill" />
+                          {{ $t('sysTools.monitor.upload') }}<i class="ri-arrow-up-s-fill" />
                         </el-col>
                         <el-col span="12" :sm="6" :md="16" class="line-value">
                           {{ info.net.out }}KB
@@ -76,7 +76,7 @@
                   </el-row>
                   <el-row :gutter="10" class="monitor-progress">
                     <el-col :sm="24" :md="4">
-                      硬盘
+                      {{ $t('sysTools.monitor.disk') }}
                     </el-col>
                     <el-col :sm="24" :md="20">
                       <el-progress :color="customColors" :text-inside="true" :stroke-width="24" :percentage="info.disk.percent" />
@@ -86,8 +86,8 @@
                 </div>
                 <!-- <div class="monitor-footer">
 
-                  <Cell label="CPU主频" :value="info.cpu.cpuInfo[0].modelName.split('@ ')[1]" border />
-                  <Cell label="核心数" :value="`${info.cpu.cpuInfo[0].cores}`" />
+                  <Cell :label="$t('sysTools.monitor.cpuFreq')" :value="info.cpu.cpuInfo[0].modelName.split('@ ')[1]" border />
+                  <Cell :label="$t('sysTools.monitor.cores')" :value="`${info.cpu.cpuInfo[0].cores}`" />
                 </div> -->
               </div>
             </el-card>
@@ -95,28 +95,28 @@
 
           <!-- <el-card v-if="info.os" class="box-card">
             <div slot="header" class="clearfix">
-              <span>go运行环境</span>
+              <span>{{ $t('sysTools.monitor.goRuntime') }}</span>
             </div>
             <div class="monitor">
-              <Cell label="GO 版本" :value="info.os.version" border />
+              <Cell :label="$t('sysTools.monitor.goVersion')" :value="info.os.version" border />
               <Cell label="Goroutine" :value="`${info.os.numGoroutine}`" border />
-              <Cell label="项目地址" :value="info.os.projectDir" />
+              <Cell :label="$t('sysTools.monitor.projectDir')" :value="info.os.projectDir" />
             </div>
           </el-card> -->
 
           <el-card v-if="info.os" class="box-card">
             <template #header>
               <div class="clearfix">
-                <span>服务器信息</span>
+                <span>{{ $t('sysTools.monitor.serverInfo') }}</span>
               </div>
             </template>
             <div class="monitor">
-              <Cell label="主机名称" :value="info.os.hostName" border />
-              <Cell label="操作系统" :value="info.os.goOs" border />
-              <Cell label="服务器IP" :value="info.os.ip" border />
-              <Cell label="系统架构" :value="info.os.arch" border />
+              <Cell :label="$t('sysTools.monitor.hostName')" :value="info.os.hostName" border />
+              <Cell :label="$t('sysTools.monitor.os')" :value="info.os.goOs" border />
+              <Cell :label="$t('sysTools.monitor.ip')" :value="info.os.ip" border />
+              <Cell :label="$t('sysTools.monitor.arch')" :value="info.os.arch" border />
               <Cell label="CPU" :value="info.cpu.cpuInfo[0].modelName" border />
-              <Cell label="当前时间" :value="info.os.time" />
+              <Cell :label="$t('sysTools.monitor.currentTime')" :value="info.os.time" />
             </div>
           </el-card>
 

--- a/tests/e2e/mocked/gen.spec.ts
+++ b/tests/e2e/mocked/gen.spec.ts
@@ -1,6 +1,16 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import { authenticate, installApiMocks } from './fixtures'
 import { captureBodies } from './support/crud'
+
+/**
+ * The suite runs in Chinese (playwright.config.ts pins the locale), so anything
+ * English has to switch first. Clicked rather than dispatched: none of the
+ * pages below has a modal open over the navbar.
+ */
+const switchTo = async(page: Page, label: string) => {
+  await page.locator('#lang-select').click()
+  await page.getByRole('menuitem', { name: label, exact: true }).click()
+}
 
 /**
  * The code generator's table list. Six row actions and a preview dialog that
@@ -279,5 +289,216 @@ test.describe('dev-tools editTable', () => {
     const dropdown = page.locator('.el-select-dropdown:visible')
     await expect(dropdown).toBeVisible()
     await expect(dropdown.locator('.el-select-dropdown__item')).toHaveCount(0)
+  })
+})
+
+/**
+ * The same three screens in English.
+ *
+ * The generator is the least-visited page in the application and the one with
+ * the most developer jargon, so these assert the words themselves rather than
+ * just "something changed": a translation that silently falls back to the key
+ * still changes the text.
+ */
+test.describe('dev-tools gen in English', () => {
+  test.beforeEach(async({ page, context }) => {
+    await authenticate(context)
+    await installApiMocks(page)
+  })
+
+  test('the list translates in place, without a reload', async({ page }) => {
+    let reloaded = false
+    page.on('framenavigated', frame => {
+      if (frame === page.mainFrame()) reloaded = true
+    })
+
+    await page.goto('/#/dev-tools/gen')
+    await page.waitForSelector('.el-table')
+    await expect(page.locator('.el-table__header')).toContainText('模型名称')
+
+    reloaded = false
+    await switchTo(page, 'English')
+
+    const header = page.locator('.el-table__header')
+    for (const label of ['ID', 'Table Name', 'Menu Name', 'Model Name', 'Created At']) {
+      await expect(header).toContainText(label)
+    }
+    await expect(page.locator('.el-table__header')).not.toContainText('模型名称')
+
+    const toolbar = page.locator('.pro-table__toolbar')
+    await expect(toolbar.getByRole('button', { name: 'Import' })).toBeVisible()
+    await expect(toolbar.getByRole('button', { name: 'Delete' })).toBeVisible()
+
+    expect(reloaded, 'the page reloaded instead of re-rendering').toBe(false)
+  })
+
+  test('the row actions and the overflow menu translate', async({ page }) => {
+    await page.goto('/#/dev-tools/gen')
+    await page.waitForSelector('.el-table')
+    await switchTo(page, 'English')
+
+    const row = page.getByRole('row', { name: /sys_demo/ })
+    await expect(row.getByRole('button', { name: 'Edit' })).toBeVisible()
+    await expect(row.getByRole('button', { name: 'Preview' })).toBeVisible()
+
+    await row.locator('.el-dropdown button').click()
+    // The language switcher is an el-dropdown too, and its popper is still on
+    // screen a moment after the switch -- so the row's menu is the one that is
+    // not offering languages.
+    const menu = page.locator('.el-dropdown-menu:visible').filter({ hasNotText: '简体中文' })
+    await expect(menu).toContainText('Generate into Project')
+    await expect(menu).toContainText('Generate Configuration')
+    await expect(menu).toContainText('Generate Migration Script')
+    await expect(menu).toContainText('Delete')
+    expect(await menu.innerText(), 'Chinese left in the menu').not.toMatch(/[一-龥]/)
+  })
+
+  test('deleting one table asks in English, in the singular', async({ page }) => {
+    // The Chinese sentence has one form. English has two, and the count decides
+    // -- a page that passed a plain string here would read "the 1 selected
+    // tables". The row menu deletes exactly one, which is the form the
+    // composable's own default never exercises.
+    await page.goto('/#/dev-tools/gen')
+    await page.waitForSelector('.el-table')
+    await switchTo(page, 'English')
+
+    const row = page.getByRole('row', { name: /sys_demo/ })
+    await row.locator('.el-dropdown button').click()
+    await page.locator('.el-dropdown-menu:visible').getByText('Delete').click()
+
+    const box = page.locator('.el-message-box')
+    await expect(box.locator('.el-message-box__message'))
+      .toHaveText('Delete the generator configuration for the selected table?')
+    expect(await box.innerText(), 'Chinese left in the dialog').not.toMatch(/[一-龥]/)
+  })
+
+  test('the preview dialog is titled in English', async({ page }) => {
+    await page.goto('/#/dev-tools/gen')
+    await page.waitForSelector('.el-table')
+    await switchTo(page, 'English')
+
+    await page.getByRole('row', { name: /sys_demo/ }).getByRole('button', { name: 'Preview' }).click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog.locator('.el-dialog__title')).toHaveText('Code Preview')
+  })
+})
+
+/**
+ * The editor, whose 字段信息 tab is the densest cluster of developer jargon in
+ * the application -- go类型, json属性, 查询方式. Its two tabs are separate
+ * components with a rule set each, and both had those rules as a module-level
+ * constant: evaluated once, at setup, which this page never re-runs because it
+ * is kept alive.
+ */
+test.describe('dev-tools editTable in English', () => {
+  test.beforeEach(async({ page, context }) => {
+    await authenticate(context)
+    await installApiMocks(page)
+    await page.goto('/#/dev-tools/editTable?tableId=1')
+    await page.waitForSelector('.el-table')
+  })
+
+  test('the tabs, the column headers and the footer translate', async({ page }) => {
+    await switchTo(page, 'English')
+
+    // Scoped to the page's own card: the tab strip above it is an el-tabs too
+    const tabs = page.locator('.el-card .el-tabs__nav')
+    await expect(tabs).toContainText('Basic Information')
+    await expect(tabs).toContainText('Field Information')
+    await expect(tabs).toContainText('Generation Information')
+
+    const header = page.locator('.el-table__header')
+    for (const label of [
+      'No.', 'Column Name', 'Description', 'DB Type', 'Go Type', 'Go Field', 'JSON Field',
+      'Edit', 'List', 'Query', 'Query Type', 'Required', 'Display Type', 'Dictionary Type',
+      'Relation Table', 'Relation Key', 'Relation Value'
+    ]) {
+      await expect(header).toContainText(label)
+    }
+    expect(await header.innerText(), 'Chinese left in the headers').not.toMatch(/[一-龥]/)
+
+    await expect(page.getByRole('button', { name: 'Back' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible()
+
+    // The alert above the table, and the two headers that carry an explanation
+    await expect(page.locator('.el-alert__title')).toContainText('are hidden from this list')
+    await page.locator('.el-table__header .field-label__hint').first().hover()
+    // role=tooltip, not .el-popper: the switcher's own popper is still fading
+    // out and is an .el-popper too
+    await expect(page.locator('[role="tooltip"]:visible'))
+      .toContainText('Whether the column appears in the list')
+  })
+
+  test('a validation message already on screen follows the language', async({ page }) => {
+    // The failure this exists for: `const rules = { ... }` at module scope is
+    // evaluated once, so a message rendered under a field keeps the language it
+    // was built in. Nothing reports it -- validation still works, the form still
+    // refuses to submit, the sentence is just in the wrong language. Asserting
+    // on a message triggered *after* the switch would not catch it, because
+    // re-triggering repaints the text either way.
+    await page.getByRole('tab', { name: '基本信息' }).click()
+
+    const author = page.getByPlaceholder('请输入作者名称')
+    await author.fill('')
+    await author.blur()
+
+    const errors = page.locator('.el-form-item__error')
+    await expect(errors.filter({ hasText: '请输入作者' })).toHaveCount(1)
+
+    await switchTo(page, 'English')
+
+    await expect(errors.filter({ hasText: 'Please enter author' })).toHaveCount(1)
+    await expect(errors.filter({ hasText: '请输入作者' })).toHaveCount(0)
+  })
+
+  test('the generation tab\'s validation message follows the language too', async({ page }) => {
+    // A second rule set in a second component. Covered separately because
+    // fixing one file and not the other leaves half a form in the old language
+    // -- and both tabs are visible one click apart.
+    await page.getByRole('tab', { name: '生成信息' }).click()
+
+    const business = page.locator('.el-form-item').filter({ hasText: '业务名' }).locator('input')
+    await business.fill('')
+    await business.blur()
+
+    const errors = page.locator('.el-form-item__error')
+    await expect(errors.filter({ hasText: '请输入生成业务名' })).toHaveCount(1)
+
+    await switchTo(page, 'English')
+
+    await expect(errors.filter({ hasText: 'Please enter the business name' })).toHaveCount(1)
+    await expect(errors.filter({ hasText: '请输入生成业务名' })).toHaveCount(0)
+  })
+
+  test('the dictionary picker offers the seeded types by their English name', async({ page }) => {
+    // These names arrive from the database, so they are Chinese in either
+    // language -- but the seeded ones have a translation keyed by dict_type,
+    // and lang/backend.ts already knows how to find it. Without that lookup the
+    // one dropdown on this page that lists backend data stays Chinese while
+    // every label around it is English. A dictionary the operator created has
+    // no entry and keeps its stored name; that is the designed fallback, and it
+    // is also what keeps the Chinese interface byte-for-byte unchanged.
+    await switchTo(page, 'English')
+
+    // Column 13 is 字典类型; 15 is the relation key the test above uses
+    const cell = page.locator('.el-table__body .el-table__row').first().locator('td').nth(13)
+    await cell.locator('.el-select').click()
+
+    const dropdown = page.locator('.el-select-dropdown:visible')
+    await expect(dropdown).toContainText('System Status')
+    await expect(dropdown).not.toContainText('系统状态')
+    // The dict_type itself is an identifier and stays as it is
+    await expect(dropdown).toContainText('sys_common_status')
+  })
+
+  test('saving reports success in English', async({ page }) => {
+    // The endpoint answers without a `msg`, so this is the client's own string.
+    // Where the backend does send one it wins, in whatever language it was
+    // written -- see the note in the batch report.
+    await switchTo(page, 'English')
+    await page.getByRole('button', { name: 'Submit' }).click()
+
+    await expect(page.locator('.el-message--success')).toContainText('Saved successfully')
   })
 })

--- a/tests/e2e/mocked/i18n.spec.ts
+++ b/tests/e2e/mocked/i18n.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test'
 import { authenticate, installApiMocks } from './fixtures'
+import { readWorkbook, values } from './support/workbook'
 
 /**
  * Switching language, and the three places that quietly do not follow.
@@ -322,6 +323,128 @@ test.describe('switching language', () => {
     await page.getByRole('menuitem', { name: 'English', exact: true }).click()
 
     await expect(dialog.locator('.el-dialog__title')).toHaveText('Add User')
+  })
+
+  /**
+   * The same freeze as the sys-user test above, on the batch that followed.
+   *
+   * Five of the seven pages in it declared `const rules: FormRules = { ... }`
+   * at setup, which runs once -- so a message built from t() there keeps the
+   * language the page was opened in, and nothing reports it: validation goes on
+   * working, the dialog goes on rejecting, the sentence under the field is just
+   * in the wrong language. Asserting on a message triggered *after* the switch
+   * would not catch it, because reopening the dialog remounts el-form-item and
+   * repaints the error either way.
+   */
+  test('translates a validation message already on screen, on a page that is not sys-user', async({ page }) => {
+    await page.goto('/#/admin/sys-post')
+    await expect(page.locator('.el-table').first()).toBeVisible({ timeout: 15000 })
+
+    await page.locator('.pro-table__toolbar').getByRole('button', { name: '新增' }).click()
+
+    const dialog = page.locator('.el-dialog:visible')
+    await expect(dialog).toContainText('添加岗位')
+    await dialog.getByRole('button', { name: '确 定' }).click()
+
+    const errors = dialog.locator('.el-form-item__error')
+    await expect(errors.filter({ hasText: '岗位名称不能为空' })).toHaveCount(1)
+
+    // Dispatched rather than clicked: the dialog's overlay covers the navbar,
+    // so the switcher is genuinely unreachable by mouse while it is open. The
+    // event still lands on el-dropdown's own handler.
+    await page.locator('#lang-select').dispatchEvent('click')
+    await page.getByRole('menuitem', { name: 'English', exact: true }).click()
+
+    await expect(errors.filter({ hasText: 'Position name is required' })).toHaveCount(1)
+    await expect(errors.filter({ hasText: '岗位名称不能为空' })).toHaveCount(0)
+    // The title is read on every render, so it has to follow the same switch.
+    await expect(dialog.locator('.el-dialog__title')).toHaveText('Add Position')
+  })
+
+  /**
+   * The settings page, which reaches el-form directly rather than through
+   * useForm -- so nothing unwraps a ref for it and the computed has to be bound
+   * straight to `:rules`. It is also the one page in the batch with no dialog:
+   * the message sits on the page itself, where a reader can stare at it for as
+   * long as they like before switching.
+   */
+  test('translates a validation message on the settings form, which has no useForm', async({ page }) => {
+    await page.goto('/#/admin/sys-config/set')
+    await page.waitForSelector('.config-section')
+
+    await page.getByPlaceholder('请输入系统名称').fill('')
+    await page.getByRole('button', { name: '保存设置' }).click()
+
+    const error = page.locator('.el-form-item__error')
+    await expect(error).toHaveText('请输入系统名称')
+
+    await switchTo(page, 'English')
+
+    await expect(error).toHaveText('Please enter system name')
+  })
+
+  /**
+   * The one confirm box in the batch that useRemove does not own.
+   *
+   * Emptying the log asks separately, through an ElMessageBox the page builds
+   * itself -- four strings that the composables' translation never touched, so
+   * they had to be read at click time here for the same reason useRemove reads
+   * its own inside the call.
+   */
+  test('empties the operation log in English, box and buttons included', async({ page }) => {
+    const { calls } = await installApiMocks(page)
+
+    await page.goto('/#/admin/sys-oper-log')
+    await expect(page.locator('.el-table').first()).toBeVisible({ timeout: 15000 })
+
+    await switchTo(page, 'English')
+    await page.locator('.pro-table__toolbar').getByRole('button', { name: 'Clear' }).click()
+
+    const box = page.locator('.el-message-box')
+    await expect(box).toBeVisible()
+    await expect(box.locator('.el-message-box__title')).toHaveText('Notice')
+    await expect(box.locator('.el-message-box__message'))
+      .toHaveText('Clear every operation log? This cannot be undone.')
+    await expect(box.getByRole('button', { name: 'OK' })).toBeVisible()
+    await expect(box.getByRole('button', { name: 'Cancel' })).toBeVisible()
+    // The four assertions above name the parts that were Chinese; this one
+    // catches whichever part is next.
+    expect(await box.innerText(), 'Chinese left in the dialog').not.toMatch(/[一-龥]/)
+
+    await box.getByRole('button', { name: 'OK' }).click()
+    await expect.poll(() => calls.extra.operLogClean).toBe(1)
+    await expect(page.locator('.el-message--success')).toContainText('Cleared')
+  })
+
+  /**
+   * The exported sheet, which is written rather than rendered.
+   *
+   * Its headings and its file name are the one piece of copy that leaves the
+   * browser, and they were built into a module-level array. Anything resolved
+   * once at setup would write Chinese headings into a workbook an English
+   * reader asked for -- and no assertion on the screen would notice, because
+   * the screen is correct.
+   */
+  test('writes the exported sheet in the language the reader asked in', async({ page }) => {
+    await page.goto('/#/admin/sys-post')
+    await expect(page.locator('.el-table').first()).toBeVisible({ timeout: 15000 })
+
+    await switchTo(page, 'English')
+    await page.locator('.pro-table__toolbar').getByRole('button', { name: 'Export' }).click()
+
+    // Located by role rather than by name: useExport still writes its own
+    // confirm in Chinese, which is not this test's subject.
+    const confirm = page.locator('.el-message-box')
+    await expect(confirm).toBeVisible()
+    const downloaded = page.waitForEvent('download')
+    await confirm.locator('.el-message-box__btns .el-button--primary').click()
+
+    const download = await downloaded
+    expect(download.suggestedFilename()).toBe('Position Management.xlsx')
+
+    const workbook = await readWorkbook(download)
+    const [header] = values(workbook)
+    expect(header).toEqual(['Position ID', 'Position Code', 'Position Name', 'Order', 'Created At'])
   })
 
   test('switches back', async({ page }) => {

--- a/tests/e2e/mocked/schedule.spec.ts
+++ b/tests/e2e/mocked/schedule.spec.ts
@@ -1,6 +1,19 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import { authenticate, installApiMocks } from './fixtures'
 import { captureBodies } from './support/crud'
+
+/**
+ * The suite runs in Chinese (playwright.config.ts pins the locale).
+ *
+ * `dispatchEvent` rather than a click: el-dialog lays .el-overlay-dialog over
+ * the whole viewport, so the navbar switcher is genuinely unreachable by mouse
+ * while a dialog is open. The event still lands on el-dropdown's own handler,
+ * so everything after it is the real path.
+ */
+const switchTo = async(page: Page, label: string) => {
+  await page.locator('#lang-select').dispatchEvent('click')
+  await page.getByRole('menuitem', { name: label, exact: true }).click()
+}
 
 /**
  * Scheduled jobs. The action column branches on two fields at once: entry_id is
@@ -117,5 +130,137 @@ test.describe('schedule', () => {
 
     await expect.poll(() => calls.job.update).toBe(1)
     expect(typeof JSON.parse(bodies.at(-1) || '{}').status).toBe('number')
+  })
+})
+
+test.describe('schedule in English', () => {
+  test.beforeEach(async({ page, context }) => {
+    await authenticate(context)
+    await installApiMocks(page)
+    await page.goto('/#/schedule/manage')
+    await page.waitForSelector('.el-table')
+  })
+
+  test('the list, its toolbar and its row actions translate', async({ page }) => {
+    await switchTo(page, 'English')
+
+    const header = page.locator('.el-table__header')
+    for (const label of ['ID', 'Name', 'Group', 'Cron Expression', 'Invoke Target', 'Status']) {
+      await expect(header).toContainText(label)
+    }
+    expect(await header.innerText(), 'Chinese left in the headers').not.toMatch(/[一-龥]/)
+
+    const toolbar = page.locator('.pro-table__toolbar')
+    await expect(toolbar.getByRole('button', { name: 'Add' })).toBeVisible()
+    await expect(toolbar.getByRole('button', { name: 'Delete' })).toBeVisible()
+    await expect(toolbar.getByRole('button', { name: 'Log' })).toBeVisible()
+
+    await expect(page.getByRole('row', { name: /清理过期日志/ })
+      .getByRole('button', { name: 'Stop' })).toBeVisible()
+    await expect(page.getByRole('row', { name: /同步用户/ })
+      .getByRole('button', { name: 'Start' })).toBeVisible()
+  })
+
+  test('the hover card behind the invoke target translates', async({ page }) => {
+    // Four interpolated sentences, and the values inside three of them are also
+    // translated -- 接口/函数, 允许/禁止, and the misfire policy, which used to
+    // be a module-level record built once.
+    await switchTo(page, 'English')
+    await page.getByRole('row', { name: /同步用户/ }).getByText('SyncUsers').hover()
+
+    const card = page.locator('.el-popover:visible')
+    await expect(card).toContainText('Args: full')
+    await expect(card).toContainText('Invoke type: Function')
+    await expect(card).toContainText('Misfire policy: Run Once')
+    await expect(card).toContainText('Concurrent: Forbid')
+  })
+
+  test('a validation message already on screen follows the language', async({ page }) => {
+    // Same failure as the generator's tabs: `const rules = { ... }` is evaluated
+    // once at setup, and this page is kept alive, so reopening the dialog does
+    // not rebuild it. useForm unwraps a ref, so a computed is all it takes --
+    // and el-form revalidates on a rule change, which is what repaints a message
+    // that is already rendered.
+    await page.getByRole('button', { name: '新增', exact: true }).click()
+
+    const dialog = page.locator('.el-dialog:visible')
+    await expect(dialog).toContainText('添加任务')
+    await dialog.getByRole('button', { name: '确 定' }).click()
+
+    const errors = dialog.locator('.el-form-item__error')
+    await expect(errors.filter({ hasText: '名称不能为空' })).toHaveCount(1)
+
+    await switchTo(page, 'English')
+
+    await expect(dialog.locator('.el-dialog__title')).toHaveText('Add Task')
+    await expect(errors.filter({ hasText: 'Name is required' })).toHaveCount(1)
+    await expect(errors.filter({ hasText: '名称不能为空' })).toHaveCount(0)
+    await expect(errors.filter({ hasText: 'Invoke target is required' })).toHaveCount(1)
+  })
+
+  test('the misfire radio group repaints while the dialog is open', async({ page }) => {
+    // The three labels came from a plain Record<number, string>, read by both
+    // the radio group and the hover card. A dialog that is already open has to
+    // follow without being closed and reopened.
+    await page.getByRole('row', { name: /清理过期日志/ }).getByRole('button', { name: '修改' }).click()
+
+    const dialog = page.locator('.el-dialog:visible')
+    await expect(dialog).toContainText('立即执行')
+
+    await switchTo(page, 'English')
+
+    await expect(dialog).toContainText('Run Immediately')
+    await expect(dialog).toContainText('Run Once')
+    await expect(dialog).toContainText('Skip')
+    await expect(dialog).not.toContainText('立即执行')
+  })
+
+  test('starting a job asks in English, box and buttons included', async({ page }) => {
+    await switchTo(page, 'English')
+    await page.getByRole('row', { name: /同步用户/ }).getByRole('button', { name: 'Start' }).click()
+
+    const box = page.locator('.el-message-box')
+    await expect(box.locator('.el-message-box__title')).toHaveText('Notice')
+    // The job's own name is Chinese in either language -- it is user data
+    await expect(box.locator('.el-message-box__message')).toHaveText('Start the task "同步用户"?')
+    await expect(box.getByRole('button', { name: 'OK' })).toBeVisible()
+    await expect(box.getByRole('button', { name: 'Cancel' })).toBeVisible()
+  })
+
+  test('deleting one job asks in English, in the singular', async({ page }) => {
+    await switchTo(page, 'English')
+    // The row's delete is the icon button, which carries the job name as its title
+    await page.getByRole('row', { name: /同步用户/ })
+      .getByTitle('Delete task: 同步用户').click()
+
+    const box = page.locator('.el-message-box')
+    await expect(box.locator('.el-message-box__message')).toHaveText('Delete the selected task?')
+  })
+})
+
+test.describe('the job log page in English', () => {
+  test.beforeEach(async({ page, context }) => {
+    await authenticate(context)
+    await installApiMocks(page)
+    await page.goto('/#/schedule/log')
+    await expect(page.locator('.job-log__viewport')).toBeVisible()
+  })
+
+  test('the console chrome translates', async({ page }) => {
+    // Nothing here refetches: the socket is opened once on mount, and the state
+    // word beside the dot was a lookup table built at setup.
+    await expect(page.locator('.job-log__count')).toHaveText('0 行')
+
+    await switchTo(page, 'English')
+
+    await expect(page.locator('.job-log__count')).toHaveText('0 lines')
+    await expect(page.getByRole('button', { name: 'Clear' })).toBeVisible()
+    // The dev server does not speak this protocol, so the socket closes and the
+    // page offers to reconnect. Either state is legitimate; both are asserted
+    // in English rather than by waiting for one.
+    await expect(page.locator('.job-log__state')).toHaveText(/Connecting|Connected|Disconnected/)
+    await expect(page.locator('.job-log__empty')).toHaveText(/waiting for task output|Not connected/)
+    expect(await page.locator('.job-log').innerText(), 'Chinese left on the page')
+      .not.toMatch(/[一-龥]/)
   })
 })


### PR DESCRIPTION
The last three page batches, done in parallel and merged here: the remaining admin pages, the code generator and scheduler, and the account/monitor/example pages. **P1 is complete with this.**

| batch | pages | keys per language |
|---|---|---|
| 2 | operation & login logs, posts, settings, both dictionary views, API list | 168 |
| 3 | four generator views, both scheduler pages | 144 |
| 4 | profile ×4, server monitor, the reference list page | ~90 |

## Vocabulary that a glossary lookup could not settle

Three departures from a literal mapping, each for a reason worth keeping:

- **物理类型 → DB Type**, not Physical Type. The column holds a SQL declaration (`varchar(64)`); the literal only parses for someone who already read the Chinese.
- **执行策略 → Misfire Policy**, not Execution Policy. Its three options describe only what happens to a run the scheduler missed — which is also what the field is named.
- **A job's 参数 → Args**, deliberately not the glossary's Parameter. That entry covers the system parameter store; these are a Go function's arguments.

And one case of the same Chinese meaning two things: 序号 is **ID** in the generator list (it binds `tableId`) but **No.** in the column editor (a row ordinal from `type="index"`).

## The pattern that keeps recurring

Every batch found more setup-time values that freeze the language: `const rules` objects, `useForm` titles, and in the scheduler two lookup tables (`MISFIRE`, `STATE_LABEL`). All are computed now. The scheduler's hover card and its radio group read the *same* table, so reverting that one fix turns two tests red — they are not independent.

## One test that could not have been written any other way

The export case unzips the workbook and reads the header row. An English interface that writes Chinese column headers **looks perfectly correct on screen** — nothing rendered is wrong — and the mistake only exists in the file the user opens afterwards.

## Verification

- Full suite: **238 passed, 0 failed** (218 + 20 new), `git rev-parse HEAD` identical before and after
- `pnpm lint` 0 errors, 30 warnings — byte-identical to master
- `pnpm type-check`, `pnpm test:unit` (297), `pnpm check:i18n` all clean
- Every new case was reverted and observed red, in groups small enough that each revert maps to a distinct test
- zh-CN unchanged was machine-checked, not eyeballed: batch 2's agent extracted every Chinese string from the `HEAD` version of its seven files and matched them against the new pack values, 7/7 with no omissions

## Reported, not fixed

Both agents independently found the same gap: **`useExport`'s confirm dialog is still hard-coded Chinese** — the composables batch fixed `useRemove` and missed it. And `msgSuccess(response.msg || t('…'))` in seven places means the server's Chinese `msg` wins over the translation, which the e2e mocks hide because they return different text than the real backend does.

Two pre-existing bugs unrelated to i18n, both matching the "no test coverage, so it broke quietly" pattern: the generator's 编辑 checkbox binds `is_insert` while the template reads both `is_insert` and `is_edit`, so `is_edit` can never be set from the UI; and `v-dialogDrag` has never functioned under Vue 3 — `el-dialog`'s root is not an element, so the directive is skipped and Vue says so on every open.

All are written up in the technical-debt list rather than folded in here.