### PR TITLE
fix🐛: rename the 编辑 column to 表单, which is what the checkbox controls

### DIFF
--- a/src/lang/en-US/dev-tools/edit-table.ts
+++ b/src/lang/en-US/dev-tools/edit-table.ts
@@ -17,7 +17,8 @@ export default {
   goField: 'Go Field',
   jsonField: 'JSON Field',
 
-  isInsert: 'Edit',
+  isInsert: 'Form',
+  isInsertTip: 'Whether the column appears in the add/edit form; ticked means it does',
   isList: 'List',
   isListTip: 'Whether the column appears in the list; ticked means it does',
   isQuery: 'Query',

--- a/src/lang/zh-CN/dev-tools/edit-table.ts
+++ b/src/lang/zh-CN/dev-tools/edit-table.ts
@@ -25,7 +25,13 @@ export default {
   goField: 'go属性',
   jsonField: 'json属性',
 
-  isInsert: '编辑',
+  // 「表单」rather than 「编辑」, which is what this column said until now.
+  // The checkbox is bound to is_insert, and is_insert decides whether the column
+  // appears in the generated 添加或修改 dialog -- a form used for both. Read next
+  // to 列表 and 查询, which say where else a column shows up, 「编辑」 reads as
+  // "may be edited" -- which is is_edit, the one flag it does not control.
+  isInsert: '表单',
+  isInsertTip: '是否出现在新增/修改表单中，打勾表示出现',
   isList: '列表',
   isListTip: '是否在列表中展示，打勾表示展示',
   isQuery: '查询',

--- a/src/views/dev-tools/gen/editTable.vue
+++ b/src/views/dev-tools/gen/editTable.vue
@@ -51,7 +51,13 @@
             </template>
           </el-table-column>
 
-          <el-table-column :label="$t('devTools.editTable.isInsert')" width="50">
+          <el-table-column :label="$t('devTools.editTable.isInsert')" width="80" align="center">
+            <template #header>
+              <FieldLabel
+                :label="$t('devTools.editTable.isInsert')"
+                :tip="$t('devTools.editTable.isInsertTip')"
+              />
+            </template>
             <template #default="scope">
               <el-checkbox v-model="scope.row.isInsert" true-value="1" false-value="0" />
             </template>

--- a/tests/e2e/mocked/gen.spec.ts
+++ b/tests/e2e/mocked/gen.spec.ts
@@ -193,23 +193,35 @@ test.describe('dev-tools editTable', () => {
     await expect(headers.first()).toBeVisible()
 
     const text = await page.locator('.el-table__header').innerText()
-    for (const label of ['字段描述', 'go类型', 'json属性', '列表', '查询', '必填', '显示类型']) {
+    for (const label of ['字段描述', 'go类型', 'json属性', '表单', '列表', '查询', '必填', '显示类型']) {
       expect(text).toContain(label)
     }
   })
 
-  test('the two explained headers carry their explanation', async({ page }) => {
+  test('the explained headers carry their explanation', async({ page }) => {
     await installApiMocks(page)
 
     await page.goto('/#/dev-tools/editTable?tableId=1')
     await page.waitForSelector('.el-table')
 
-    // Two headers carry an explanation; the rest are plain labels
+    // Three headers carry an explanation; the rest are plain labels. 表单 joined
+    // them when it was renamed: it is the column most easily misread, so it is
+    // the one that most needed saying what it does.
     const hints = page.locator('.el-table__header .field-label__hint')
-    await expect(hints).toHaveCount(2)
+    await expect(hints).toHaveCount(3)
 
-    await hints.first().hover()
-    await expect(page.locator('.el-popper:visible')).toContainText('是否在列表中展示')
+    // In column order -- 表单, 列表, 查询.
+    for (const [index, expected] of [
+      [0, '是否出现在新增/修改表单中'],
+      [1, '是否在列表中展示'],
+      [2, '是否作为搜索条件']
+    ] as Array<[number, string]>) {
+      await hints.nth(index).hover()
+      // Located by its own text rather than by :visible -- hovering the next
+      // hint while the previous tooltip is still fading out leaves two of them
+      // on screen, and a bare :visible matches both.
+      await expect(page.locator('.el-popper').filter({ hasText: expected })).toBeVisible()
+    }
   })
 
   test('the columns load into editable rows', async({ page }) => {
@@ -411,7 +423,7 @@ test.describe('dev-tools editTable in English', () => {
     const header = page.locator('.el-table__header')
     for (const label of [
       'No.', 'Column Name', 'Description', 'DB Type', 'Go Type', 'Go Field', 'JSON Field',
-      'Edit', 'List', 'Query', 'Query Type', 'Required', 'Display Type', 'Dictionary Type',
+      'Form', 'List', 'Query', 'Query Type', 'Required', 'Display Type', 'Dictionary Type',
       'Relation Table', 'Relation Key', 'Relation Value'
     ]) {
       await expect(header).toContainText(label)
@@ -421,13 +433,16 @@ test.describe('dev-tools editTable in English', () => {
     await expect(page.getByRole('button', { name: 'Back' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible()
 
-    // The alert above the table, and the two headers that carry an explanation
+    // The alert above the table, and the headers that carry an explanation
     await expect(page.locator('.el-alert__title')).toContainText('are hidden from this list')
+    // first() is now the Form column, which gained its hint when it was renamed
+    // from Edit -- the label that read as "may be edited", the one flag the
+    // checkbox does not control.
     await page.locator('.el-table__header .field-label__hint').first().hover()
     // role=tooltip, not .el-popper: the switcher's own popper is still fading
     // out and is an .el-popper too
     await expect(page.locator('[role="tooltip"]:visible'))
-      .toContainText('Whether the column appears in the list')
+      .toContainText('Whether the column appears in the add/edit form')
   })
 
   test('a validation message already on screen follows the language', async({ page }) => {


### PR DESCRIPTION
The checkbox in the generator's column editor was labelled 编辑 / Edit and bound
to `is_insert`.

`is_insert` decides whether a column appears in the generated 添加或修改 dialog —
a form used for adding *and* editing. Sitting next to 列表 and 查询, which say
where else a column shows up, 编辑 reads as "may be edited" — which is `is_edit`,
the one flag this checkbox does not control.

### Why rename rather than add a second checkbox

`is_edit` is not just unreachable from the interface. It has never been connected
at any layer:

| | |
|---|---|
| Import | never assigns `IsEdit`, so it stays `""` |
| Interface | no control writes it |
| Template | tests `eq .IsEdit "false"` — and these checkboxes write `"1"`/`"0"`, so even a new control would not have matched |

Wiring it up means changing the import default, the template comparison, and the
interface — three changes to enable a feature nobody has asked for. Naming the
control that does exist is the smaller fix, and the honest one.

### Also

The column gains the explanation its two neighbours already had, and their width.
It was the column most easily misread and the only one of the three with nothing
to read.

Three assertions moved with it. One is worth noting: the header test listed seven
labels and this column was not among them, so the rename would have gone
unnoticed there. It is in the list now.
