### PR TITLE
chore🔧: bump the version to 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-admin",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A magical vue admin. An out-of-box UI solution for enterprise applications. Newest development stack of vue. Lots of awesome features",
   "author": "https://github.com/wenjianzhang",
   "license": "MIT",


### PR DESCRIPTION
Version bump only. The release notes go on the tag.

Fifteen days and twenty-seven merged pull requests since 3.1.0. The one thing to
know when upgrading: the interface now follows the visitor's browser language, so
an English-language browser lands on the English interface where it previously
always saw Chinese. No backend change and no database migration.