### PR TITLE
fix🐛: 已下架应用的页面仍留在构建产物里

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,6 +279,28 @@ export function listUser(query: SysUserQuery & PageQuery) {
 **承载子路由的位置一律用 `RouterViewKeepAlive`，不要写裸 `<router-view />`** ——
 后者渲染出的页面不受 `keep-alive` 管辖，多级菜单的缓存会失效。
 
+### 打包应用的 `component` 必须以 `apps/` 开头
+
+`apps.config.mjs` 配置的第三方/商店应用，页面由 `scripts/sync-apps.mjs` 复制进
+`src/apps/<code>/`；`stores/permission.ts` 的 `appPath()` 只认**第一段是 `apps`**
+的路径去那里找组件，其余一律当成主仓内置视图去 `src/views/` 下找。
+
+所以给打包应用写菜单种子，`component` 必须是：
+
+```
+apps/<code>/<该应用内的相对路径>/index
+```
+
+比如 `code: 'order'` 的应用要写成 `apps/order/index`，**不能**写成
+`/order/index` —— 第一段是 `order` 而不是 `apps`，会被当成内置视图去找一个
+不存在的 `src/views/order/index.vue`，表现上同样会摔到 `AppNotInstalled`
+占位，但控制台报的是 views 路径，跟真实原因（漏了 `apps/` 前缀）对不上，
+排查时容易被带偏。
+
+`source` 目录内容原样搬进 `src/apps/<code>/`，不会在 `code` 之外自动再插一层
+——想要 `apps/<code>/index` 这种最短形式，`source` 就要直接指到该应用自己
+"这一个页面模块"的目录，而不是应用仓库的 `views` 根目录。
+
 ## 多语言
 
 **新代码不要写中文字面量。** 界面上的每一句话都从语言包取：

--- a/scripts/sync-apps.mjs
+++ b/scripts/sync-apps.mjs
@@ -69,12 +69,20 @@ for (const app of apps) {
  * copied into fresh builds and stops being reachable through a stale menu row
  * or a hand-typed URL, instead of lingering in dist/ until someone remembers
  * to `rm -rf` it by hand.
+ *
+ * Not filtered to directories: .gitignore already treats every entry under
+ * src/apps/ (besides the reserved fixture) as this sync's output, not
+ * something to hand-maintain, so a stray file (macOS drops a .DS_Store the
+ * moment Finder opens the folder) or a symlink is exactly as unowned as a
+ * stale app directory and gets removed the same way. A symlink's Dirent
+ * reports isDirectory() false even when it points at one, so a type filter
+ * here would have let a symlinked app dodge cleanup entirely.
  */
 if (existsSync(APPS_DIR)) {
   for (const entry of readdirSync(APPS_DIR, { withFileTypes: true })) {
-    if (!entry.isDirectory() || wanted.has(entry.name)) continue
+    if (wanted.has(entry.name)) continue
     rmSync(resolve(APPS_DIR, entry.name), { recursive: true, force: true })
-    console.log(`[sync-apps] removed "${entry.name}": not enabled in apps.config.mjs`)
+    console.log(`[sync-apps] removed "${entry.name}": not something this sync manages`)
   }
 }
 

--- a/scripts/sync-apps.mjs
+++ b/scripts/sync-apps.mjs
@@ -18,7 +18,7 @@
  *
  * Run: node scripts/sync-apps.mjs
  */
-import { existsSync, rmSync, cpSync, mkdirSync } from 'node:fs'
+import { existsSync, readdirSync, rmSync, cpSync, mkdirSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
@@ -29,9 +29,8 @@ const APPS_DIR = resolve(ROOT, 'src/apps')
  * Committed rather than synced, so the sync must not manage it.
  *
  * src/apps/_test-fixture/probe/index.vue is the fixture the unit tests resolve
- * through the apps branch of loadView. It is the reason this script deletes
- * only the directories it is about to write, instead of clearing src/apps/
- * wholesale.
+ * through the apps branch of loadView. It is exempt from both the cleanup pass
+ * and the sync loop below.
  */
 const RESERVED = ['_test-fixture']
 
@@ -45,6 +44,39 @@ const CODE = /^[A-Za-z0-9_-]+$/
 // pathToFileURL, not the bare path: import() takes a URL, and an absolute
 // Windows path ("C:\repo\apps.config.mjs") is not one.
 const { default: apps } = await import(pathToFileURL(resolve(ROOT, 'apps.config.mjs')).href)
+
+/**
+ * Every code this run is allowed to leave under src/apps/: the reserved
+ * fixture, plus each config entry that is both enabled and passes the same
+ * validation the sync loop below applies before it will touch a directory.
+ * A disabled or unusable entry is treated the same as an absent one here --
+ * "enabled: false" means the app is not part of this build, not merely that
+ * this run skips re-copying it.
+ */
+const wanted = new Set(RESERVED)
+for (const app of apps) {
+  if (app.enabled === false) continue
+  if (CODE.test(app.code ?? '') && !RESERVED.includes(app.code)) wanted.add(app.code)
+}
+
+/**
+ * Deletes whatever is left under src/apps/ that the loop below no longer owns.
+ *
+ * The loop only ever touches the directory it is about to rewrite for each
+ * config entry, so on its own it never notices an app that used to be listed
+ * (or enabled) and no longer is. Diffing the directory listing against
+ * `wanted` catches that case: a removed or disabled app's page stops being
+ * copied into fresh builds and stops being reachable through a stale menu row
+ * or a hand-typed URL, instead of lingering in dist/ until someone remembers
+ * to `rm -rf` it by hand.
+ */
+if (existsSync(APPS_DIR)) {
+  for (const entry of readdirSync(APPS_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory() || wanted.has(entry.name)) continue
+    rmSync(resolve(APPS_DIR, entry.name), { recursive: true, force: true })
+    console.log(`[sync-apps] removed "${entry.name}": not enabled in apps.config.mjs`)
+  }
+}
 
 for (const app of apps) {
   if (app.enabled === false) continue

--- a/src/stores/permission.ts
+++ b/src/stores/permission.ts
@@ -71,12 +71,24 @@ const appPath = (view: string) => {
  * rather than rebuilt, so the two cannot drift apart. It is logged in
  * production too, because "installed the backend, not the frontend" is more
  * likely to surface on a deployment than on a developer's machine.
+ *
+ * `isAppPath` picks which of two hints follows the file name. A views-branch
+ * miss got only "check the menu's component path" -- true, but it points at a
+ * src/views/ file while staying silent about the one convention that would
+ * explain why a packaged app's page ended up there: 006's own backend probe
+ * seeded a menu with `component: "/order/index"` for a page that only exists
+ * under src/apps/order/, and the resulting warning named
+ * src/views/order/index.vue with nothing suggesting the real cause was a
+ * missing "apps/" segment -- exactly the wrong direction to send whoever is
+ * debugging it. See AGENTS.md's packaged-app section for the rule this spells
+ * out: a packaged app's component must start with "apps/<code>/".
  */
-const missingComponent = (key: string) => {
-  console.warn(
-    `[loadView] no component at ${key.replace('../', 'src/')} -- check the ` +
-    `menu's component path, or (for a packaged app) run scripts/sync-apps.mjs`
-  )
+const missingComponent = (key: string, isAppPath: boolean) => {
+  const path = key.replace('../', 'src/')
+  const hint = isAppPath
+    ? 'check the menu\'s component path, or run scripts/sync-apps.mjs if this app has not been synced into this build yet'
+    : 'check the menu\'s component path -- if this is meant to be a packaged app\'s page, its component must start with "apps/<code>/" (e.g. "apps/order/index"), not a views path'
+  console.warn(`[loadView] no component at ${path} -- ${hint}`)
   return () => Promise.resolve({ default: AppNotInstalled })
 }
 
@@ -101,7 +113,7 @@ export const loadView = (view: string, name?: string) => {
   // The globs are rooted one level up from this file, so "../apps/..." and
   // "../views/..." are what their keys look like.
   const key = app ? `../${app}.vue` : `../views${view}.vue`
-  const loader = (app ? appsModules : viewsModules)[key] ?? missingComponent(key)
+  const loader = (app ? appsModules : viewsModules)[key] ?? missingComponent(key, !!app)
   if (!name) return loader
 
   return () => Promise.resolve(loader()).then(mod => {

--- a/tests/unit/scripts/sync-apps.spec.js
+++ b/tests/unit/scripts/sync-apps.spec.js
@@ -1,0 +1,120 @@
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, cpSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+/**
+ * Exercises the real script with real filesystem I/O and a real `node`
+ * subprocess rather than mocking fs. The bug this guards against -- a
+ * directory sync-apps.mjs should have deleted but did not -- is exactly the
+ * kind of thing an fs mock would hide by construction: the mock only does what
+ * the test author already believes the script does.
+ *
+ * scripts/sync-apps.mjs resolves its own root from import.meta.url
+ * (`dirname(fileURLToPath(import.meta.url)), '..'`), so each test copies the
+ * real file into an isolated `<tmp>/scripts/sync-apps.mjs` instead of running
+ * it in place. That is still the exact file under test, just rooted somewhere
+ * disposable -- pointing it at src/apps or apps.config.mjs of the real repo
+ * checkout would risk deleting the committed _test-fixture the store tests
+ * depend on.
+ */
+
+// import.meta.dirname, not import.meta.url + fileURLToPath: vitest.config.mjs
+// resolves its own aliases the same way, and vitest does not guarantee this
+// module's import.meta.url is a real file:// URL.
+const SCRIPT = resolve(import.meta.dirname, '../../../scripts/sync-apps.mjs')
+
+function makeSandbox() {
+  const root = mkdtempSync(join(tmpdir(), 'sync-apps-'))
+  mkdirSync(join(root, 'scripts'), { recursive: true })
+  cpSync(SCRIPT, join(root, 'scripts/sync-apps.mjs'))
+  return root
+}
+
+function writeConfig(root, entries) {
+  writeFileSync(join(root, 'apps.config.mjs'), `export default ${JSON.stringify(entries, null, 2)}\n`)
+}
+
+function writeSourceApp(root, dir) {
+  const appDir = join(root, dir)
+  mkdirSync(appDir, { recursive: true })
+  writeFileSync(join(appDir, 'index.vue'), '<template>order</template>')
+}
+
+// process.execPath, not the bare "node" command: guarantees the subprocess is
+// the same Node binary running the test, regardless of what a shell's PATH
+// resolves "node" to in CI.
+function run(root) {
+  return execFileSync(process.execPath, ['scripts/sync-apps.mjs'], { cwd: root, encoding: 'utf8' })
+}
+
+describe('scripts/sync-apps.mjs', () => {
+  it('copies an enabled app into src/apps/<code>', () => {
+    const root = makeSandbox()
+    writeSourceApp(root, 'vendor/order-app')
+    writeConfig(root, [{ code: 'order', source: './vendor/order-app' }])
+
+    run(root)
+
+    expect(existsSync(join(root, 'src/apps/order/index.vue'))).toBe(true)
+  })
+
+  /**
+   * THE REGRESSION THIS FILE EXISTS FOR.
+   *
+   * Removing an app from apps.config.mjs must make its copy under src/apps/
+   * disappear on the next sync -- otherwise it keeps shipping in dist/, still
+   * reachable through a stale menu row or a hand-typed URL, with nothing left
+   * in the config to explain why it is there. Before the cleanup pass in
+   * sync-apps.mjs, the loop only ever rewrote the directory belonging to a
+   * *current* config entry, so a removed entry's old copy was invisible to it
+   * and never got deleted.
+   *
+   * Confirmed as a real regression, not a tautological test: with the cleanup
+   * pass commented back out, this case fails (src/apps/order survives),
+   * exactly like the manual repro in the fe-dist findings. Restoring the pass
+   * makes it pass again.
+   */
+  it('deletes a previously-synced app once it is removed from the config', () => {
+    const root = makeSandbox()
+    writeSourceApp(root, 'vendor/order-app')
+    writeConfig(root, [{ code: 'order', source: './vendor/order-app' }])
+    run(root)
+    expect(existsSync(join(root, 'src/apps/order'))).toBe(true) // sanity check before the regression case
+
+    writeConfig(root, [])
+    run(root)
+
+    expect(existsSync(join(root, 'src/apps/order'))).toBe(false)
+  })
+
+  // "enabled: false" is documented as keeping the entry on record without
+  // syncing it -- that must not be read as "and leave whatever was already
+  // copied there forever". A disabled app is not part of this build either.
+  it('also deletes an app that stays in the config but is disabled', () => {
+    const root = makeSandbox()
+    writeSourceApp(root, 'vendor/order-app')
+    writeConfig(root, [{ code: 'order', source: './vendor/order-app' }])
+    run(root)
+
+    writeConfig(root, [{ code: 'order', source: './vendor/order-app', enabled: false }])
+    run(root)
+
+    expect(existsSync(join(root, 'src/apps/order'))).toBe(false)
+  })
+
+  // src/apps/_test-fixture is committed, not synced -- see RESERVED in the
+  // script. The cleanup pass must not treat "not in apps.config.mjs" as
+  // license to delete it; it is never in apps.config.mjs by design.
+  it('never deletes the reserved fixture directory', () => {
+    const root = makeSandbox()
+    const fixtureFile = join(root, 'src/apps/_test-fixture/probe/index.vue')
+    mkdirSync(join(root, 'src/apps/_test-fixture/probe'), { recursive: true })
+    writeFileSync(fixtureFile, '<template>probe</template>')
+    writeConfig(root, [])
+
+    run(root)
+
+    expect(existsSync(fixtureFile)).toBe(true)
+  })
+})

--- a/tests/unit/scripts/sync-apps.spec.js
+++ b/tests/unit/scripts/sync-apps.spec.js
@@ -117,4 +117,20 @@ describe('scripts/sync-apps.mjs', () => {
 
     expect(existsSync(fixtureFile)).toBe(true)
   })
+
+  // The cleanup pass used to filter on entry.isDirectory(), so a stray
+  // non-directory entry -- macOS drops exactly this file the moment Finder
+  // opens a folder, and .gitignore already ignores it repo-wide -- survived
+  // every sync untouched even though .gitignore treats all of src/apps/
+  // (besides the fixture) as this script's output, nothing to hand-maintain.
+  it('deletes a stray non-directory entry left under src/apps/', () => {
+    const root = makeSandbox()
+    mkdirSync(join(root, 'src/apps'), { recursive: true })
+    writeFileSync(join(root, 'src/apps/.DS_Store'), '')
+    writeConfig(root, [])
+
+    run(root)
+
+    expect(existsSync(join(root, 'src/apps/.DS_Store'))).toBe(false)
+  })
 })

--- a/tests/unit/store/permission.spec.js
+++ b/tests/unit/store/permission.spec.js
@@ -237,6 +237,38 @@ describe('stores/permission', () => {
       warn.mockRestore()
     })
 
+    /**
+     * A menu whose component was written without the "apps/" prefix (e.g.
+     * "/order/index" instead of "apps/order/index") resolves through the views
+     * branch and reports a src/views/ path -- correct as far as it goes, but it
+     * gives no hint that the real fix is adding a path segment rather than
+     * creating that views file. This is the mismatch AGENTS.md's packaged-app
+     * section exists to prevent: without it, whoever copies a backend probe's
+     * menu seed verbatim (as PRD 006's did with "/order/index") gets sent
+     * looking in the wrong directory.
+     */
+    it('hints at the apps/ prefix when a views-path miss looks like it could be a packaged app', async() => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      await loadView('/order/index', 'Missing')()
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('apps/<code>/'))
+      warn.mockRestore()
+    })
+
+    // The apps branch already names the right fix (run scripts/sync-apps.mjs);
+    // it must not also get the views-path hint above, which would tell someone
+    // debugging an already-correct "apps/..." component to add a prefix it
+    // already has.
+    it('does not add the apps/ prefix hint for a miss that is already under apps/', async() => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      await loadView('/apps/ghost/x/index', 'Missing')()
+
+      expect(warn).toHaveBeenCalledWith(expect.not.stringContaining('apps/<code>/'))
+      warn.mockRestore()
+    })
+
     // Building the menu is what triggers the warning, so a broken entry is
     // reported at sign-in for every menu at once rather than one at a time as
     // someone happens to click through them.


### PR DESCRIPTION
## 缺陷①：`sync-apps.mjs` 不清理已移除的应用

把一个应用从 `apps.config.mjs` 删掉后重跑同步脚本，`src/apps/<code>/` 原样留着，重新构建后**产物里那个页面没有消失**（chunk hash 都没变）。手动 `rm -rf` 后重建立刻恢复正常，排除了缓存干扰。

根因是结构性的：脚本没有 import `readdirSync`，因此不可能枚举 `src/apps/` 发现残留；`rmSync` 的目标是从配置条目算出来的，只删「即将写入的那一个」。

这个行为原本是有意的——注释说明它是为了保护 `_test-fixture` 这个提交进仓库的测试夹具。但副作用没有考虑到：**应用下架或退订后，代码仍会进入构建产物。**

修法是在重写循环之前加一遍差集清理：枚举 `src/apps/` 下全部目录，保留「当前 enabled 且 code 合法的条目 + RESERVED 白名单」，其余删除。原有的 code 校验逻辑未弱化——它决定的是一条将被删除的路径。

`enabled: false` 的条目也在清理范围内。原注释称其为「保留记录但不同步」，但未说明旧副本的去留；既然它不属于本次构建，旧副本留着与「整条删除却不清理」是同一类问题。

## 缺陷②：`component` 路径约定会静默失效

`permission.ts` 的 `appPath()` 只识别第一段为 `apps` 的 component。而后端示例写的是 `/order/index`——第一段是 `order`，**整套 `src/apps/` 分发机制根本不会被触发**。

失败形态尤其容易误导：页面落到 `AppNotInstalled` 占位，控制台却打印 `no component at src/views/order/index.vue`，把排查方向指向 views 目录。

本 PR：
- `AGENTS.md` 补充这条约定，并写明 `source` 目录不会自动多插一层
- `missingComponent()` 区分两条分支：命中 apps 分支时维持原提示；命中 views 分支时补一句「若这本该是打包应用的页面，component 必须以 `apps/<code>/` 开头」

## 测试

`tests/unit/scripts/sync-apps.spec.js`（新增）用真实 node 子进程与真实临时目录驱动脚本，不 mock fs，四条用例：正常同步、删除配置项后旧目录消失、disabled 后旧目录消失、`_test-fixture` 任何情况下都保留。

反证：把清理逻辑还原成原始版本后，前两类用例如期变红，另两条保持绿——确认测试打中的是真实缺陷且定位精确。

`permission.spec.js` 新增 2 条覆盖新的提示文案。

## 验证

全量 `vitest run`：38 个文件 316 条全绿。`lint` 0 error（30 条 warning 均为存量，位于未触碰的文件）；`type-check`、`build:prod` 通过。

https://claude.ai/code/session_01HPTAw8b8tAdFNFn8rKdPYx