### PR TITLE
fix(ci): 契约检查跟上后端契约面下沉，读不到基类时报原因

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -28,6 +28,25 @@ jobs:
           repository: go-admin-team/go-admin
           path: go-admin
 
+      # The bases every model embeds -- id, createdAt, createBy and the rest --
+      # are declared in go-admin-core now, and common/models only aliases them.
+      # Read at the version go-admin actually depends on rather than the tip of
+      # the default branch: the fields this compares against are the ones the
+      # running server sends, which is the pinned release.
+      - name: resolve the go-admin-core version
+        id: core
+        run: |
+          ref=$(grep -oE 'go-admin-core/v2 v[0-9]+\.[0-9]+\.[0-9]+' go-admin/go.mod | head -1 | awk '{print $2}')
+          test -n "$ref" || { echo "no go-admin-core/v2 requirement in go-admin/go.mod"; exit 1; }
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
+      - name: checkout go-admin-core
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: go-admin-team/go-admin-core
+          ref: ${{ steps.core.outputs.ref }}
+          path: go-admin-core
+
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
@@ -55,6 +74,7 @@ jobs:
         run: pnpm check:api -- --require-models
         env:
           GO_ADMIN_PATH: ${{ github.workspace }}/go-admin
+          GO_ADMIN_CORE_PATH: ${{ github.workspace }}/go-admin-core
 
       # The menu and dictionary packs are keyed by the backend's own seed data,
       # so a typo in a key falls back to Chinese and looks like an untranslated

--- a/scripts/check-api-contract.mjs
+++ b/scripts/check-api-contract.mjs
@@ -104,6 +104,16 @@ for (const [root, dir] of MODEL_DIRS) {
   }
 }
 
+/**
+ * Embedded bases no directory above declares.
+ *
+ * Reported on their own rather than left to surface as missing fields. When
+ * ModelTime could not be read, every model looked as though it had lost
+ * createdAt and the run printed 32 field mismatches -- each one true as stated
+ * and all of them the same single cause, which is a poor way to learn that a
+ * source directory has moved.
+ */
+const unresolved = new Set()
 
 /** Flattens a struct's own and embedded fields into jsonName -> goType. */
 const fieldsOf = (name, seen = new Set()) => {
@@ -111,8 +121,10 @@ const fieldsOf = (name, seen = new Set()) => {
   seen.add(name)
   const out = {}
   for (const [json, type] of structs[name]) {
-    if (json === '@embed') Object.assign(out, fieldsOf(type, seen))
-    else out[json] = type
+    if (json === '@embed') {
+      if (!structs[type]) unresolved.add(type)
+      Object.assign(out, fieldsOf(type, seen))
+    } else out[json] = type
   }
   return out
 }
@@ -334,6 +346,23 @@ for (const block of declaredTypes.matchAll(/export interface (\w+) \{([^}]*)\}/g
 
   note(`src/types/admin.ts ${name}`, 'declared but not on the model',
     declared.filter(f => !(f in fields) && !allowed.has(f) && !ALLOWED.has(f)))
+}
+
+/*
+ * Checked before the mismatches: an unreadable base makes its fields look
+ * missing everywhere at once, so reporting those first would bury the cause
+ * under its symptoms.
+ */
+if (unresolved.size) {
+  const bases = [...unresolved].sort().join(', ')
+  const where = `embedded by the models but declared nowhere this can read: ${bases}`
+  const hint = `go-admin's common/models aliases them into go-admin-core; point GO_ADMIN_CORE_PATH at a checkout of it (looked in ${CORE})`
+  if (required) {
+    console.error(`cannot check the api contract: ${where}\n  ${hint}`)
+    process.exit(1)
+  }
+  console.log(`skipped: ${where}\n  ${hint}`)
+  process.exit(0)
 }
 
 if (problems.length) {

--- a/scripts/check-api-contract.mjs
+++ b/scripts/check-api-contract.mjs
@@ -36,6 +36,10 @@ const GO = process.env.GO_ADMIN_PATH ?? join(UI, '..', 'go-admin')
  */
 const CORE = process.env.GO_ADMIN_CORE_PATH ?? join(UI, '..', 'go-admin-core')
 
+/** Where in that repository the bases live -- named once, so the diagnostic
+ *  below names the directory actually read rather than the repository root. */
+const CORE_MODELS = 'sdk/contract/models'
+
 /**
  * Skipping keeps a UI-only checkout building; --require-models turns the skip
  * into a failure, which is what CI passes. Without it a broken checkout step
@@ -89,7 +93,7 @@ const MODEL_DIRS = [
   [GO, 'app/other/models/tools'], // the code generator's own tables
   // Last, so a base the Go repository still declares itself is the one used.
   // This is where the aliased ones are read from once it has stopped.
-  [CORE, 'sdk/contract/models']
+  [CORE, CORE_MODELS]
 ]
 
 const structs = {}
@@ -355,8 +359,8 @@ for (const block of declaredTypes.matchAll(/export interface (\w+) \{([^}]*)\}/g
  */
 if (unresolved.size) {
   const bases = [...unresolved].sort().join(', ')
-  const where = `embedded by the models but declared nowhere this can read: ${bases}`
-  const hint = `go-admin's common/models aliases them into go-admin-core; point GO_ADMIN_CORE_PATH at a checkout of it (looked in ${CORE})`
+  const where = `${bases} are embedded by the models but declared in no source this reads`
+  const hint = `go-admin's common/models aliases them into go-admin-core; point GO_ADMIN_CORE_PATH at a checkout of it (looked for ${join(CORE, CORE_MODELS)})`
   if (required) {
     console.error(`cannot check the api contract: ${where}\n  ${hint}`)
     process.exit(1)

--- a/scripts/check-api-contract.mjs
+++ b/scripts/check-api-contract.mjs
@@ -25,6 +25,18 @@ const UI = join(dirname(fileURLToPath(import.meta.url)), '..')
 const GO = process.env.GO_ADMIN_PATH ?? join(UI, '..', 'go-admin')
 
 /**
+ * go-admin-core, which owns the bases every model embeds.
+ *
+ * common/models used to declare ControlBy, Model and ModelTime itself; since
+ * the contract surface moved down into go-admin-core (its PRD 006) it declares
+ * them as type aliases into that repository instead. An alias is the same type,
+ * so nothing changed on the wire -- but the fields those bases carry (id,
+ * createdAt, updatedAt, createBy, updateBy) are now declared over there, and a
+ * checkout without it can only conclude that every model has lost them.
+ */
+const CORE = process.env.GO_ADMIN_CORE_PATH ?? join(UI, '..', 'go-admin-core')
+
+/**
  * Skipping keeps a UI-only checkout building; --require-models turns the skip
  * into a failure, which is what CI passes. Without it a broken checkout step
  * would leave this job green while it checked nothing at all.
@@ -70,24 +82,28 @@ const parseStructs = source => {
 const goFiles = dir => readdirSync(dir).filter(f => f.endsWith('.go')).map(f => join(dir, f))
 
 const MODEL_DIRS = [
-  'common/models',
-  'app/admin/models',
-  'app/demo/models', // the reference module
-  'app/jobs/models', // scheduled jobs
-  'app/other/models/tools' // the code generator's own tables
+  [GO, 'common/models'],
+  [GO, 'app/admin/models'],
+  [GO, 'app/demo/models'], // the reference module
+  [GO, 'app/jobs/models'], // scheduled jobs
+  [GO, 'app/other/models/tools'], // the code generator's own tables
+  // Last, so a base the Go repository still declares itself is the one used.
+  // This is where the aliased ones are read from once it has stopped.
+  [CORE, 'sdk/contract/models']
 ]
 
 const structs = {}
-for (const dir of MODEL_DIRS) {
-  const path = join(GO, dir)
+for (const [root, dir] of MODEL_DIRS) {
+  const path = join(root, dir)
   if (!existsSync(path)) continue
   for (const file of goFiles(path)) {
     for (const [name, fields] of Object.entries(parseStructs(readFileSync(file, 'utf8')))) {
-      // First directory wins: common/models holds the embedded bases
+      // First directory wins, so the order above is the resolution order
       if (!(name in structs)) structs[name] = fields
     }
   }
 }
+
 
 /** Flattens a struct's own and embedded fields into jsonName -> goType. */
 const fieldsOf = (name, seen = new Set()) => {


### PR DESCRIPTION
## 现象

`Verify` 的 `api contract` 这一步在 master 上是红的，**任何** PR 都会带上这条红：

```
API contract mismatch (32):

  fixtures.ts userRows -> SysUser
    not on the model: createdAt
  ...
```

32 条，全部是 `createdAt` 或 `id`。前端这一侧没有任何改动能解释它——把后端远端 master 导出成快照后，在 master（`d30d2ad`）上跑同一条 `check:api --require-models`，同样是这 32 条。

## 根因

后端的契约面下沉（go-admin PRD 006）之后，`common/models/by.go` 变成了这样：

```go
import contractmodels "github.com/go-admin-team/go-admin-core/v2/sdk/contract/models"

type (
	ControlBy = contractmodels.ControlBy
	Model     = contractmodels.Model
	ModelTime = contractmodels.ModelTime
)
```

别名是同一个类型，GORM tag、JSON tag、方法集都没变，**线上行为完全不受影响**。

但 `check-api-contract.mjs` 是靠正则扫 Go 源码找 `type ModelTime struct {` 来展开嵌入字段的。这个 struct 已经不在 go-admin 仓库里了，于是脚本展开不出 `createdAt` / `id`，每个嵌入它的模型看上去都少了这些字段。

## 改法

**一、把 `sdk/contract/models` 加进搜索路径**（`GO_ADMIN_CORE_PATH`，默认 `../go-admin-core`）。

放在搜索顺序**最后**：后端自己还声明的基类优先，这样脚本对下沉前后的两种后端都成立，不会因为后端回滚而反过来出错。

**二、CI 按后端 `go.mod` 锁定的版本 checkout core**，而不是取默认分支的 tip：

```yaml
ref=$(grep -oE 'go-admin-core/v2 v[0-9]+\.[0-9]+\.[0-9]+' go-admin/go.mod | head -1 | awk '{print $2}')
```

这个检查比对的应该是**运行中的服务真正会发出的字段**，那就是它依赖的那个 release（当前 `v2.6.0`），不是 core 主线上还没发布的改动。否则 core 一改主线，前端 CI 就会为一个还没上线的变更变红——正是这次的同类问题。

**三、读不到的嵌入基类，报成它自己**（第二条提交）。

原先"读不到一个基类"会伪装成 32 条字段缺失：每条单看都成立、全部指向同一个原因、没有一条说出那个原因。从"userRows 少了 createdAt"倒推到"一个源码目录搬走了"要绕好几步，而脚本本来就掌握着直接说出来的信息。现在它先报：

```
cannot check the api contract: embedded by the models but declared nowhere this can read: ControlBy, Model, ModelTime
  go-admin's common/models aliases them into go-admin-core; point GO_ADMIN_CORE_PATH at a checkout of it (looked in ...)
```

## 验证

对着三种真实情形跑（后端用远端 master 快照，core 用 `v2.6.0` tag 快照，即 CI 将来的确切组合）：

| 情形 | 结果 |
|---|---|
| 旧后端（基类还在自己仓库里），不给 core | ok |
| 新后端，不给 core | 一条诊断，指出是哪三个基类、找过哪个路径 |
| 新后端 + core v2.6.0 | ok |

**反证**：把 core 里 `createdAt` 的 json tag 改成 `created_at`，检查如期报出 26 条真实 mismatch——确认它没有被改成永远绿，仍然抓得住字段真的改名这类事故。

`lint` 0 error、单测 317 全绿。
