### PR TITLE
fix(tags-view): 标签上边框被 nav wrapper 裁掉，测试读的是声明值所以一直没发现

### DIFF
--- a/src/layout/components/TagsView/index.vue
+++ b/src/layout/components/TagsView/index.vue
@@ -320,6 +320,21 @@ String.prototype.colorRgb = function() {
     align-items: flex-end;
   }
 
+  // Sized to the tab, for the same reason the header above is: Element Plus
+  // gives this wrapper 31px, one short of the 32px tab it holds, and it clips.
+  //
+  // The pixel it cut was the tab's top border. Every tab therefore rendered as
+  // an open-topped box while the border stayed declared, computed, and reported
+  // as present by anything reading getComputedStyle -- which is what the test
+  // covering this was doing.
+  //
+  // The scroller inside clips as well and needs the same height; fixing only
+  // the wrapper moves the cut one element down.
+  .el-tabs__nav-wrap,
+  .el-tabs__nav-scroll {
+    height: 32px;
+  }
+
   .el-tabs__nav-wrap {
     margin-bottom: 0;
     &::after { display: none; }
@@ -330,6 +345,10 @@ String.prototype.colorRgb = function() {
   }
 
   .el-tabs__item {
+    // Element Plus lifts a card tab by a pixel so that neighbours share one
+    // edge. These tabs are spaced 3px apart and share nothing, so the only
+    // thing the offset did was push the top border out of the wrapper above.
+    margin-top: 0 !important;
     height: 32px;
     line-height: 32px;
     font-size: 12px;

--- a/tests/e2e/mocked/tags-view-chrome.spec.ts
+++ b/tests/e2e/mocked/tags-view-chrome.spec.ts
@@ -48,14 +48,52 @@ test.describe('the tab strip', () => {
     expect(tab!.y, 'the tab starts below the navbar').toBeGreaterThanOrEqual(navbar!.y + navbar!.height)
   })
 
-  test('every tab has a visible top border', async({ page }) => {
-    const borders = await page.locator('.el-tabs__item').evaluateAll(nodes =>
-      nodes.map(node => getComputedStyle(node as HTMLElement).borderTopWidth)
-    )
+  /**
+   * Declared and rendered are different things, and this is the check that
+   * knows the difference.
+   *
+   * The rule was applied, getComputedStyle reported `1px solid #d9d9d9` on all
+   * four sides, and the top edge was still not on screen: Element Plus lifts a
+   * card tab a pixel so that neighbours share an edge, .el-tabs__nav-wrap is a
+   * pixel shorter than the tab and clips, and the pixel it cut was that border.
+   * Reading the style could never have caught it -- the style was correct.
+   *
+   * Walking every clipping ancestor rather than naming nav-wrap: the previous
+   * version compared the tab against .el-tabs__header, which does not clip, so
+   * it passed for the whole time the border was missing.
+   */
+  test('nothing clips a tab, so its declared borders are all on screen', async({ page }) => {
+    const problems = await page.locator('.el-tabs__item').evaluateAll(nodes => {
+      const clipped: string[] = []
 
-    expect(borders.length).toBeGreaterThan(0)
-    // Declared and rendered are different things -- this only proves the rule
-    // applies. The geometry checks above are what prove it is on screen.
-    expect(borders.every(width => parseFloat(width) > 0), `border widths: ${borders}`).toBe(true)
+      for (const node of nodes as HTMLElement[]) {
+        const label = node.textContent?.trim() || '(unnamed)'
+        const style = getComputedStyle(node)
+        if (parseFloat(style.borderTopWidth) <= 0) {
+          clipped.push(`${label}: no top border declared`)
+          continue
+        }
+
+        const box = node.getBoundingClientRect()
+        for (let parent = node.parentElement; parent; parent = parent.parentElement) {
+          const overflowY = getComputedStyle(parent).overflowY
+          if (overflowY === 'visible') continue
+
+          const bounds = parent.getBoundingClientRect()
+          const where = `${parent.className || parent.tagName.toLowerCase()} (${overflowY})`
+          // Half a pixel of slack for subpixel layout; a cut border is a whole one.
+          if (box.top < bounds.top - 0.5) {
+            clipped.push(`${label}: top ${box.top} cut by ${where} starting at ${bounds.top}`)
+          }
+          if (box.bottom > bounds.bottom + 0.5) {
+            clipped.push(`${label}: bottom ${box.bottom} cut by ${where} ending at ${bounds.bottom}`)
+          }
+        }
+      }
+
+      return clipped
+    })
+
+    expect(problems, problems.join(' | ')).toEqual([])
   })
 })

--- a/tests/e2e/mocked/tags-view-chrome.spec.ts
+++ b/tests/e2e/mocked/tags-view-chrome.spec.ts
@@ -61,8 +61,14 @@ test.describe('the tab strip', () => {
    * Walking every clipping ancestor rather than naming nav-wrap: the previous
    * version compared the tab against .el-tabs__header, which does not clip, so
    * it passed for the whole time the border was missing.
+   *
+   * Vertical only, and deliberately. The strip is a fixed 40px, so a tab cut
+   * off at the top or bottom is always a defect. Sideways it is the opposite:
+   * the strip scrolls, and clipping the tab that runs past its right-hand edge
+   * is what a scrolling row is supposed to do -- checking left and right here
+   * would fail on any window narrow enough to need it.
    */
-  test('nothing clips a tab, so its declared borders are all on screen', async({ page }) => {
+  test('a tab keeps its top and bottom borders on screen, not just declared', async({ page }) => {
     const problems = await page.locator('.el-tabs__item').evaluateAll(nodes => {
       const clipped: string[] = []
 


### PR DESCRIPTION
## 现象

标签栏里**每个标签的上边线都看不到**，标签看起来是个"上面开口的盒子"。左、右、下三条边都在。

## 这不是样式漏写

`getComputedStyle` 报的是四条边都有：

```
border-top: 1px solid rgb(217, 217, 217)
border-bottom: 1px solid rgb(217, 217, 217)
border-left: 1px solid rgb(217, 217, 217)
```

但把单个标签元素截出来逐像素读，第 0 行是纯白：

| 边 | 像素 |
|---|---|
| 左 | `(217,217,217)` |
| 右 | `(217,217,217)` |
| 下 | `(217,217,217)` |
| **上** | **`(255,255,255)`** |

规则生效了，那一行就是没画出来。

## 根因

三件事叠在一起：

1. `.el-tabs__header` 是 `align-items: flex-end`，子元素贴底对齐
2. Element Plus 给 card 型标签设了 `margin-top: -1px`，让相邻标签共用一条边 —— 标签因此比它的容器高出 1px，且是往**上**顶出去的
3. `.el-tabs__nav-wrap` 和它内部的 `.el-tabs__nav-scroll` 都是 31px（Element Plus 默认）对 32px 的标签，且都 `overflow: hidden`

于是标签被抬上去的那 1px 落在容器外，被裁掉 —— 那 1px 正好是上边框。

实测的几何：

```
.el-tabs__nav-wrap    y=58..89  h=31  overflow=hidden   ← 裁切者
.el-tabs__nav-scroll  y=58..89  h=31  overflow=hidden   ← 同样
.el-tabs__item        y=57..89  h=32                    ← 顶上这 1px 在容器外
```

## 改法

这套标签之间隔着 3px、本来就不共用边，那个 `-1px` 只做了一件事：把上边框顶出容器。所以去掉它，并把两层 wrapper 按它们要装的标签来定尺寸（header 上面早就是这么做的，注释里还写着当初为什么）。

改完：

```
.el-tabs__nav-wrap    y=57..89
.el-tabs__nav-scroll  y=57..89
.el-tabs__item        y=57..89   ← 四条边都在容器内
```

像素复验：普通标签顶边 `(217,217,217)`，激活标签顶边 `(147,191,255)`（主题蓝），激活标签底边 `(255,255,255)` —— 与内容区连通，card 型标签本来就该这样。

## 那条测试为什么没拦住

`tags-view-chrome.spec.ts` 有一条 `every tab has a visible top border`，全程绿着。两个原因：

- 它读 `borderTopWidth`，而这个值**一直是对的**，问题从来不在样式声明
- 它的几何部分比的是 `.el-tabs__header` —— 那一层**不裁切**

这条测试的名字承诺了"可见"，实现只证明了"声明了"，它自己的注释也承认这一点。现在改成走**每一个会裁切的祖先**，并报出是谁裁了谁：

```
首页: top 57 cut by el-tabs__nav-scroll (hidden) starting at 58
首页: top 57 cut by el-tabs__nav-wrap is-top (hidden) starting at 58
```

**反证**：回退样式修复、只留测试，新测试如期变红并打印上面这两行，而**原有的两条测试仍然全绿** —— 这正说明旧的覆盖不到这个缺陷。

## 验证

`lint` 0 error（30 条 warning 均为存量、位于未触碰文件）、`type-check` 通过、`pnpm e2e` 250 条全绿。


## 这是同一个缺陷的第二次修复

`2ff97b7`（已合并）修过一次，标题就叫 *stop the tab strip clipping the tabs' top border*。它把 `.el-tabs__header` 从 `height: 100%` 改成 `34px`，症状消失了。

但裁切链上有三层：

| 层 | 上次 | 现在（修复前） |
|---|---|---|
| `.el-tabs__header` | `100%` → 改成 `34px` ✅ | 34px，不裁 |
| `.el-tabs__nav-wrap` | 没动 | **31px，overflow:hidden** ← 现在的裁切者 |
| `.el-tabs__nav-scroll` | 没动 | **31px，overflow:hidden** ← 同上 |

修一层，裁切就落到下一层，症状原样复发。

测试也踩了同一个坑两次。上次的提交信息里写着 *"The first version of this test passed against the bug"* —— 它当时改了测试，改完比的是 `.el-tabs__header`。那一层此后确实不裁切了，所以测试从此永远绿，而 `nav-wrap` 接手裁切之后它一无所知。

所以这次不再对着某一层写断言：**遍历标签的每一个会裁切的祖先**，谁裁的就报谁。再多一层、或者 Element Plus 升级后换了结构，它都能指出来。
