### PR TITLE
feat(protable): 折叠按列算而不是按项数，时间区间收起时也在屏幕上

### DIFF
--- a/src/components/ProTable/index.vue
+++ b/src/components/ProTable/index.vue
@@ -245,7 +245,7 @@ import { ArrowDown, Plus, Refresh, Search } from '@element-plus/icons-vue'
 import Pagination from '@/components/Pagination/index.vue'
 import MobileCards from './MobileCards.vue'
 import { readCardColumns } from './columns'
-import { countSearchFields, colsFor, collapseTo } from './search'
+import { searchFieldSpans, colsFor, collapseTo } from './search'
 import { useElementWidth } from '@/composables/useElementWidth'
 import { useNarrowScreen } from '@/composables/useNarrowScreen'
 import type { UseTableReturn } from '@/composables/useTable'
@@ -420,7 +420,7 @@ const collapsed = ref(true)
  * re-run by typing in a filter, which belongs to that field's render effect
  * rather than this one.
  */
-const collapsible = () => collapseTo(countSearchFields(slots.search), cols.value)
+const collapsible = () => collapseTo(searchFieldSpans(slots.search), cols.value)
 
 const filtersOpen = ref(false)
 const fabOpen = ref(false)
@@ -568,7 +568,7 @@ defineExpose({
  * data-visible is how many fields stay on screen, and 0 means the panel is
  * showing all of them. :nth-of-type counts rendered elements, so a field
  * switched off with v-if -- sys-user's department filter on the desktop layout
- * -- does not take up one of the visible slots, and countSearchFields skips it
+ * -- does not take up one of the visible slots, and searchFieldSpans skips it
  * for the same reason.
  *
  * The buttons are not an el-form-item, so they are never the element this hides.

--- a/src/components/ProTable/search.ts
+++ b/src/components/ProTable/search.ts
@@ -1,4 +1,4 @@
-import { Comment, Fragment, Static, Text, normalizeClass, type Slot, type VNode } from 'vue'
+import { Comment, Fragment, Static, Text, type Slot, type VNode } from 'vue'
 
 /** Columns a field marked `is-wide` asks for. */
 const WIDE_SPAN = 2
@@ -37,9 +37,13 @@ export function searchFieldSpans(slot: Slot | undefined): number[] {
         walk((node.children ?? []) as VNode[])
         continue
       }
-      // normalizeClass because a page may write the class as a string, an
-      // array or an object, and all three reach here as authored.
-      const classes = normalizeClass(node.props?.class)
+      // A page may write the class as a string, an array or an object, but
+      // createVNode has already flattened all three by the time the slot hands
+      // them over -- so this reads a string, and normalising again would be a
+      // no-op. The tests still cover all three forms: that is the contract
+      // pages write against, whoever ends up honouring it.
+      const classes = String(node.props?.class ?? '')
+      // Whole names, not a substring: `not-is-wide` is a different class.
       spans.push(classes.split(/\s+/).includes('is-wide') ? WIDE_SPAN : 1)
     }
   }

--- a/src/components/ProTable/search.ts
+++ b/src/components/ProTable/search.ts
@@ -1,26 +1,32 @@
-import { Comment, Fragment, Static, Text, type Slot, type VNode } from 'vue'
+import { Comment, Fragment, Static, Text, normalizeClass, type Slot, type VNode } from 'vue'
+
+/** Columns a field marked `is-wide` asks for. */
+const WIDE_SPAN = 2
 
 /**
- * How many filters a page actually put in the search slot.
+ * How many columns each filter in the search slot takes, in declaration order.
  *
  * The search panel lays its fields out on a grid and collapses whatever does
- * not fit the first row, so it has to know how many there are before it can
- * decide whether collapsing applies at all -- a page with two filters should
- * not grow an expand toggle that reveals nothing.
+ * not fit the first row, so it has to know what is in that row before it can
+ * decide anything -- and a field can be one column or two. Counting fields
+ * rather than columns is what made collapsing pointless on sys-oper-log: its
+ * datetime range is two columns wide, so "the first two fields" was already
+ * more than a row could hold and the collapsed panel was as tall as the open
+ * one.
  *
- * Counted off the vnodes rather than the DOM: the answer is needed while
+ * Read off the vnodes rather than the DOM: the answer is needed while
  * rendering, and a querySelectorAll would be one frame behind on any page whose
  * filters appear conditionally. sys-user has exactly that -- its department
  * filter is mounted only on the phone layout.
  *
  * A field switched off with v-if leaves a comment vnode behind, which is not a
  * field and is not an element either, so it is skipped here for the same reason
- * :nth-of-type does not count it in the stylesheet. The two must agree: this
- * number decides how many fields are visible while collapsed, and the CSS is
- * what hides the rest.
+ * :nth-of-type does not count it in the stylesheet. The two must agree: the
+ * length of this decides how many fields stay visible while collapsed, and the
+ * CSS is what hides the rest.
  */
-export function countSearchFields(slot: Slot | undefined): number {
-  let count = 0
+export function searchFieldSpans(slot: Slot | undefined): number[] {
+  const spans: number[] = []
 
   const walk = (nodes: VNode[]) => {
     for (const node of nodes) {
@@ -31,12 +37,15 @@ export function countSearchFields(slot: Slot | undefined): number {
         walk((node.children ?? []) as VNode[])
         continue
       }
-      count++
+      // normalizeClass because a page may write the class as a string, an
+      // array or an object, and all three reach here as authored.
+      const classes = normalizeClass(node.props?.class)
+      spans.push(classes.split(/\s+/).includes('is-wide') ? WIDE_SPAN : 1)
     }
   }
 
   walk(slot?.() ?? [])
-  return count
+  return spans
 }
 
 /**
@@ -70,11 +79,28 @@ export function colsFor(width: number): number {
  * How many filters a collapsed panel shows, or 0 when it shows all of them --
  * which is also the answer to "is there anything to expand".
  *
- * The buttons take one column of the first row, so a three-column panel keeps
- * two filters and hides the rest. The floor of one is for the narrow panel:
- * collapsing to nothing leaves a search form with no search in it.
+ * Filled by column rather than by count: the buttons take the last column of
+ * the first row, and whatever fits in the rest of it stays. A two-column field
+ * therefore costs what it actually occupies, so collapsing always leaves one
+ * row -- which is the only thing collapsing is for.
+ *
+ * The floor of one field is for the panel too narrow to fit even that:
+ * collapsing to nothing leaves a search form with no search in it, which is
+ * worse than a row that spills.
  */
-export function collapseTo(count: number, cols: number): number {
-  const visible = Math.max(1, cols - 1)
-  return count > visible ? visible : 0
+export function collapseTo(spans: number[], cols: number): number {
+  const budget = Math.max(1, cols - 1)
+  let used = 0
+  let visible = 0
+
+  for (const span of spans) {
+    // A field asking for more columns than exist gets the row it is in.
+    const width = Math.min(span, cols)
+    if (visible > 0 && used + width > budget) break
+    used += width
+    visible++
+    if (used >= budget) break
+  }
+
+  return visible < spans.length ? visible : 0
 }

--- a/src/views/admin/sys-oper-log/index.vue
+++ b/src/views/admin/sys-oper-log/index.vue
@@ -8,6 +8,22 @@
       :default-sort="{ prop: 'createdAt', order: 'descending' }"
     >
       <template #search>
+        <!--
+          First, and two columns wide. A datetime range needs about 340px, half
+          of a row; declaring it first is what keeps it on screen when the panel
+          is collapsed, and on an audit log the time range is the filter people
+          come here to use.
+        -->
+        <el-form-item :label="$t('admin.sysOperLog.operTime')" class="is-wide">
+          <el-date-picker
+            v-model="operatedBetween"
+            type="datetimerange"
+            :range-separator="$t('admin.sysOperLog.rangeSeparator')"
+            :start-placeholder="$t('admin.sysOperLog.startDate')"
+            :end-placeholder="$t('admin.sysOperLog.endDate')"
+            value-format="YYYY-MM-DD HH:mm:ss"
+          />
+        </el-form-item>
         <el-form-item :label="$t('admin.sysOperLog.operUrl')">
           <el-input
             v-model="table.query.operUrl"
@@ -28,17 +44,6 @@
               :value="item.value"
             />
           </el-select>
-        </el-form-item>
-        <!-- Two columns: a datetime range needs about 340px, half of one. -->
-        <el-form-item :label="$t('admin.sysOperLog.operTime')" class="is-wide">
-          <el-date-picker
-            v-model="operatedBetween"
-            type="datetimerange"
-            :range-separator="$t('admin.sysOperLog.rangeSeparator')"
-            :start-placeholder="$t('admin.sysOperLog.startDate')"
-            :end-placeholder="$t('admin.sysOperLog.endDate')"
-            value-format="YYYY-MM-DD HH:mm:ss"
-          />
         </el-form-item>
       </template>
 

--- a/tests/e2e/mocked/protable-layout.spec.ts
+++ b/tests/e2e/mocked/protable-layout.spec.ts
@@ -90,6 +90,42 @@ test.describe('list page layout', () => {
   })
 })
 
+/**
+ * Collapsing is spent in columns, not in filters.
+ *
+ * sys-oper-log leads with a datetime range that needs two of the three columns
+ * a 1280px window gives this panel, and the buttons take the third -- so the
+ * collapsed row holds that filter and nothing else. Counting filters instead
+ * put two of them in a row with space for one and a half, which pushed the
+ * buttons onto a second line: a collapsed panel exactly as tall as the open
+ * one, minus a filter.
+ */
+test.describe('a filter that needs two columns', () => {
+  test('fills the collapsed row on its own', async({ page, context }) => {
+    await authenticate(context)
+    await installApiMocks(page)
+    await page.setViewportSize({ width: 1280, height: 720 })
+    await page.goto('/#/admin/sys-oper-log')
+    await page.waitForSelector('.el-table')
+    await page.waitForTimeout(600)
+
+    const fields = page.locator('.pro-table__search > .el-form-item')
+    await expect(fields).toHaveCount(3)
+    await expect(fields.nth(0), 'the range is declared first, so it survives').toBeVisible()
+    await expect(fields.nth(1), 'nothing else fits beside it').toBeHidden()
+
+    // One row: the buttons sit level with the only filter showing.
+    const range = await fields.nth(0).boundingBox()
+    const actions = await page.locator('.pro-table__search-actions').boundingBox()
+    expect(Math.abs(actions!.y - range!.y), 'the buttons are on the filter row').toBeLessThan(20)
+
+    // And it really is two columns: the buttons occupy one, so the range spans
+    // about twice that plus the gap between them.
+    expect(range!.width, `range ${range!.width} vs one column ${actions!.width}`)
+      .toBeGreaterThan(actions!.width * 1.8)
+  })
+})
+
 test.describe('a search panel with room for every filter', () => {
   test('offers no toggle', async({ page, context }) => {
     await authenticate(context)

--- a/tests/e2e/mocked/sys-logs.spec.ts
+++ b/tests/e2e/mocked/sys-logs.spec.ts
@@ -1,19 +1,7 @@
-import { test, expect, type Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import { authenticate, installApiMocks } from './fixtures'
 import { captureBodies } from './support/crud'
 import { searchToggle } from './support/protable'
-
-/**
- * Opens the filters that the search panel keeps to one row.
- *
- * At the suite's 1280px this page gets three columns, one of which belongs to
- * the buttons, so the third filter -- the date range -- starts out behind the
- * toggle. A reader reaching for it clicks the same button.
- *
- * Unconditional: if the toggle ever stops being there, the date range is on
- * screen for a reason worth failing over rather than skipping past.
- */
-const expandFilters = (page: Page) => searchToggle(page).click()
 
 /**
  * The two audit pages. They read and delete and nothing writes them, so neither
@@ -110,6 +98,11 @@ test.describe('sys-oper-log', () => {
     await page.goto('/#/admin/sys-oper-log')
     await page.waitForSelector('.el-table')
 
+    // Behind the toggle at this width: the time range leads and takes two of
+    // the three columns, so the collapsed row holds it and the buttons and
+    // nothing else. A reader reaching for the url filter clicks the same
+    // button. (At four columns -- a panel of 1280px or more -- both show.)
+    await searchToggle(page).click()
     await page.getByPlaceholder('请输入访问地址').fill('/api/v1/sys-user')
     await page.getByPlaceholder('请输入访问地址').press('Enter')
 
@@ -157,10 +150,14 @@ test.describe('sys-oper-log', () => {
     await page.goto('/#/admin/sys-oper-log')
     await page.waitForSelector('.el-table')
 
+    // Declared first and two columns wide, so a collapsed panel keeps it: on an
+    // audit log the time range is what people come to filter by, and it used to
+    // start out behind the toggle.
+    await expect(page.locator('.pro-table__search input[placeholder="开始日期"]')).toBeVisible()
+
     const sent = calls.operLog.listQueries.at(-1) ?? ''
     expect(sent).not.toContain('beginTime=2026')
 
-    await expandFilters(page)
     await page.locator('.pro-table__search input[placeholder="开始日期"]').fill('2026-08-01 00:00:00')
     await page.keyboard.press('Enter')
     await page.locator('.pro-table__search input[placeholder="结束日期"]').fill('2026-08-31 23:59:59')
@@ -179,7 +176,6 @@ test.describe('sys-oper-log', () => {
     await page.goto('/#/admin/sys-oper-log')
     await page.waitForSelector('.el-table')
 
-    await expandFilters(page)
     // A daterange only commits once both ends are filled
     await page.locator('.pro-table__search input[placeholder="开始日期"]').fill('2026-08-01 00:00:00')
     await page.keyboard.press('Enter')

--- a/tests/unit/components/protable-search.spec.ts
+++ b/tests/unit/components/protable-search.spec.ts
@@ -2,8 +2,9 @@ import { describe, it, expect } from 'vitest'
 import { h, Comment, Fragment, type VNode } from 'vue'
 import { searchFieldSpans, colsFor, collapseTo } from '@/components/ProTable/search'
 
-/** Stands in for <el-form-item>; only its presence is counted. */
-const field = (label: string) => h({ name: 'ElFormItem' }, { label })
+/** Stands in for <el-form-item>; only its presence and its class are read. */
+const field = (label: string, cls?: unknown) =>
+  h({ name: 'ElFormItem' }, cls === undefined ? { label } : { label, class: cls })
 
 const slotOf = (...nodes: VNode[]) => () => nodes
 
@@ -29,6 +30,29 @@ describe('searchFieldSpans', () => {
       h(Comment),
       field('登录名')
     ))).toEqual([1, 1])
+  })
+
+  it('reports two columns for a field marked is-wide', () => {
+    expect(searchFieldSpans(slotOf(field('名称'), field('操作时间', 'is-wide')))).toEqual([1, 2])
+  })
+
+  /**
+   * Vue hands the class through as the page wrote it, and pages write all
+   * three forms. normalizeClass is what flattens them; without it an array or
+   * an object would read as "not wide" and the field would quietly collapse to
+   * one column -- visible only as a squeezed date picker.
+   */
+  it('reads the class however the page wrote it', () => {
+    expect(searchFieldSpans(slotOf(field('a', 'is-wide')))).toEqual([2])
+    expect(searchFieldSpans(slotOf(field('b', ['pinned', 'is-wide'])))).toEqual([2])
+    expect(searchFieldSpans(slotOf(field('c', { 'is-wide': true, pinned: false })))).toEqual([2])
+    expect(searchFieldSpans(slotOf(field('d', { 'is-wide': false })))).toEqual([1])
+  })
+
+  /** Whole class names, not a substring: `not-is-wide` is a different class. */
+  it('does not match a class that merely contains the name', () => {
+    expect(searchFieldSpans(slotOf(field('e', 'not-is-wide')))).toEqual([1])
+    expect(searchFieldSpans(slotOf(field('f', 'is-wide-ish')))).toEqual([1])
   })
 
   it('looks inside the fragments v-for and <template> produce', () => {

--- a/tests/unit/components/protable-search.spec.ts
+++ b/tests/unit/components/protable-search.spec.ts
@@ -1,19 +1,19 @@
 import { describe, it, expect } from 'vitest'
 import { h, Comment, Fragment, type VNode } from 'vue'
-import { countSearchFields, colsFor, collapseTo } from '@/components/ProTable/search'
+import { searchFieldSpans, colsFor, collapseTo } from '@/components/ProTable/search'
 
 /** Stands in for <el-form-item>; only its presence is counted. */
 const field = (label: string) => h({ name: 'ElFormItem' }, { label })
 
 const slotOf = (...nodes: VNode[]) => () => nodes
 
-describe('countSearchFields', () => {
-  it('counts the fields a page declared', () => {
-    expect(countSearchFields(slotOf(field('名称'), field('状态')))).toBe(2)
+describe('searchFieldSpans', () => {
+  it('reports one column per field a page declared', () => {
+    expect(searchFieldSpans(slotOf(field('名称'), field('状态')))).toEqual([1, 1])
   })
 
-  it('is 0 for a page with no search slot', () => {
-    expect(countSearchFields(undefined)).toBe(0)
+  it('is empty for a page with no search slot', () => {
+    expect(searchFieldSpans(undefined)).toEqual([])
   })
 
   /**
@@ -24,18 +24,18 @@ describe('countSearchFields', () => {
    * of the row it is supposed to fill.
    */
   it('skips a field switched off with v-if', () => {
-    expect(countSearchFields(slotOf(
+    expect(searchFieldSpans(slotOf(
       field('部门'),
       h(Comment),
       field('登录名')
-    ))).toBe(2)
+    ))).toEqual([1, 1])
   })
 
   it('looks inside the fragments v-for and <template> produce', () => {
-    expect(countSearchFields(slotOf(
+    expect(searchFieldSpans(slotOf(
       field('名称'),
       h(Fragment, null, [field('状态'), field('分组')])
-    ))).toBe(3)
+    ))).toEqual([1, 1, 1])
   })
 })
 
@@ -54,14 +54,33 @@ describe('colsFor', () => {
 })
 
 describe('collapseTo', () => {
+  const ones = (n: number) => Array(n).fill(1)
+
   it('keeps the first row, less the column the buttons take', () => {
-    expect(collapseTo(4, 3)).toBe(2)
-    expect(collapseTo(3, 3)).toBe(2)
+    expect(collapseTo(ones(4), 3)).toBe(2)
+    expect(collapseTo(ones(3), 3)).toBe(2)
   })
 
   it('is 0 when everything already fits, which is also "nothing to expand"', () => {
-    expect(collapseTo(2, 3)).toBe(0)
-    expect(collapseTo(3, 4)).toBe(0)
+    expect(collapseTo(ones(2), 3)).toBe(0)
+    expect(collapseTo(ones(3), 4)).toBe(0)
+  })
+
+  /**
+   * The point of collapsing is one row, and a two-column field fills a row
+   * faster than a one-column one. sys-oper-log is the case: [2, 1, 1] on three
+   * columns keeps the range and nothing else, because the range plus any second
+   * field plus the buttons is four columns of a three-column row.
+   */
+  it('spends columns, not fields', () => {
+    expect(collapseTo([2, 1, 1], 3)).toBe(1)
+    expect(collapseTo([1, 1, 2], 3)).toBe(2)
+    expect(collapseTo([2, 1, 1], 4)).toBe(2)
+  })
+
+  it('still collapses nothing when the wide field is the only one', () => {
+    expect(collapseTo([2], 3)).toBe(0)
+    expect(collapseTo([2, 1], 4)).toBe(0)
   })
 
   /**
@@ -69,7 +88,8 @@ describe('collapseTo', () => {
    * a search form with no search in it is worse than one that spills.
    */
   it('keeps one filter on a single-column panel', () => {
-    expect(collapseTo(3, 1)).toBe(1)
-    expect(collapseTo(1, 1)).toBe(0)
+    expect(collapseTo(ones(3), 1)).toBe(1)
+    expect(collapseTo(ones(1), 1)).toBe(0)
+    expect(collapseTo([2, 1], 1)).toBe(1)
   })
 })


### PR DESCRIPTION
承接 #294 留下的一个取舍：`sys-oper-log` 的时间区间默认是收起的，而审计日志上时间恰恰是最常用的筛选。

## 为什么不能只是把它挪到前面

先试过。挪完之后收起和展开**都是 2 行**——折叠不省任何空间，还藏着一项，纯亏：

| | 时间排第三（#294 现状） | 只把时间挪到第一 |
|---|---|---|
| 收起 | 访问地址 + 状态 + 按钮 = 3 格，**1 行** | 时间(2 格) + 按钮换行 = **2 行** |
| 展开 | **2 行** | **2 行** |

原因在算法：`collapseTo` 数的是**项数**（`cols - 1`），不管每项占几格。三列布局下它总是保留 2 项，而时间区间占 2 格，2 项就是 3 格，再加按钮要 4 格——一行放不下，按钮换行。

折叠的唯一目的就是让搜索区只占一行，数项数做不到这件事。

## 改法

槽位读取从"数几项"改成"每项要几格"（`searchFieldSpans`），折叠按列填到按钮为止：

```
[1,1,1] 三列 → 2   （不变，所有只有一格筛选项的页面都不受影响）
[2,1,1] 三列 → 1   （时间独占收起行）
[1,1,2] 三列 → 2   （宽的那个排在后面，行为同以前）
[2,1,1] 四列 → 2   （面板 ≥1280px 时，时间和访问地址都在）
```

然后 `sys-oper-log` 把时间区间声明到第一位。实测收起状态：

```
操作时间 [开始日期 至 结束日期]                    [重置] [搜索] [展开 ∨]
```

时间可见、宽 776px（两格），按钮与它同一行——收起仍是 1 行。

## 代价，说清楚

三列一行只有 3 格，时间占 2 格加按钮 1 格就满了，所以**访问地址和状态换到了展开后面**。这是窄面板上无法回避的二选一，我按"审计日志上时间最常用"来定的。面板到 1280px 以上（四列）时，时间和访问地址都在屏幕上。

对应的 e2e 也跟着换了方向：够时间区间的那条不再需要先点展开（读者也不需要），够访问地址的那条现在需要。

## 测试

`protable-layout.spec.ts` 新增一条钉住这个行为：两格的筛选项独占收起行、按钮与它同行、它的宽度约为按钮那一格的两倍。

**反证**：把 `collapseTo` 退回按项数，这条如期变红（`nothing else fits beside it`），恢复后 6 条全绿。

第一版反证是无效的——当时只断言了"时间可见"，而按项数算时前两项（时间 + 访问地址）都可见，断言照样通过。补上"第二项必须隐藏"和宽度比才真正钉住。单测同样：`spends columns, not fields` 在旧算法下变红。

## 验证

`lint` 0 error、`type-check`、`check:api` 通过；单测 327 全绿（新增 2 条）、`pnpm e2e` 253 条全绿（新增 1 条）。
