### PR TITLE
fix(layout): 收起后 logo 被 Tailwind utility 隐藏；页头两条缝对齐并统一

### DIFF
--- a/src/layout/components/Navbar.vue
+++ b/src/layout/components/Navbar.vue
@@ -101,23 +101,20 @@ export default {
 
 <style lang="scss" scoped>
 .navbar {
-  height: 50px;
+  height: var(--ga-header-h);
   overflow: hidden;
   position: relative;
   background: var(--ga-bg-container);
   border-bottom: 1px solid var(--ga-border-light);
   box-shadow: var(--ga-shadow-sm);
 
-  &::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    height: 2px;
-    background: linear-gradient(90deg, var(--ga-brand) 0%, var(--el-color-primary-light-3) 100%);
-    opacity: 0.7;
-  }
+  // No accent line under the navbar. It was 2px of the most saturated colour in
+  // the interface, drawn across the main column only -- so once the logo block
+  // and this one were the same height, the seam under the header read as one
+  // grey line on the left and a blue bar on the right. A page header divides;
+  // the 1px border does that, and the brand colour is better spent on things
+  // that can be clicked. It also sat 2px above the tab strip's own top border,
+  // which is close enough that a missing border there read as this covering it.
 
   .hamburger-container {
     line-height: 46px;

--- a/src/layout/components/Sidebar/Logo.vue
+++ b/src/layout/components/Sidebar/Logo.vue
@@ -1,5 +1,14 @@
 <template>
-  <div class="sidebar-logo-container" :class="{'collapse':collapse}">
+  <!--
+    is-collapsed, not collapse: `collapse` is a Tailwind utility name, and v4
+    generates utilities on demand from whatever words it finds in the source.
+    Writing the class here is what made it emit `.collapse{visibility:collapse}`
+    in the utilities layer -- and since nothing in this file sets visibility,
+    that rule had no competitor and hid the whole logo the moment the rail
+    collapsed. Element and image were still laid out, which is why it read as an
+    empty box rather than a missing element.
+  -->
+  <div class="sidebar-logo-container" :class="{'is-collapsed':collapse}">
     <transition name="sidebarLogoFade">
       <router-link v-if="collapse" key="collapse" class="sidebar-logo-link" to="/">
         <img v-if="showLogo" :src="appInfo.sys_app_logo" class="sidebar-logo" @error="showLogo = false">
@@ -64,8 +73,10 @@ export default {
 .sidebar-logo-container {
   position: relative;
   width: 100%;
-  height: 64px;
-  line-height: 64px;
+  // Shared with the navbar, so the rule under this block and the one under it
+  // land on the same line -- see --ga-header-h.
+  height: var(--ga-header-h);
+  line-height: var(--ga-header-h);
   // Part of the rail, not a plaque laid on top of it. This was a brand-colour
   // gradient, which put the most saturated block in the interface against the
   // darkest one and read as a patch rather than a header -- and on a light rail
@@ -120,7 +131,7 @@ export default {
     }
   }
 
-  &.collapse {
+  &.is-collapsed {
     .sidebar-logo {
       margin-right: 0;
     }

--- a/src/styles/sidebar.scss
+++ b/src/styles/sidebar.scss
@@ -43,7 +43,7 @@
 
     &.has-logo {
       .el-scrollbar {
-        height: calc(100% - 64px);
+        height: calc(100% - var(--ga-header-h));
       }
     }
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -87,6 +87,18 @@
   --ga-sidebar-light-hover: rgba(0, 0, 0, 0.04);
   --ga-sidebar-light-title: rgba(0, 0, 0, 0.88);
 
+  /* ── Metrics ───────────────────────────────────────────────────
+   * The page header runs across both columns: the navbar on the right and the
+   * sidebar's logo block on the left. They are two elements in two files, and
+   * the seam under them only reads as one line if they are the same height --
+   * which they were not (64px against 50px, so the two rules sat 14px apart).
+   * One number, referenced by both, makes that structural rather than a
+   * coincidence anyone can undo by editing one file.
+   *
+   * The sidebar's scroll area subtracts it too, so the menu still starts right
+   * below the logo. */
+  --ga-header-h: 50px;
+
   /* ── Shape ─────────────────────────────────────────────────────── */
   --ga-radius-sm: 4px;
   --ga-radius:    6px;

--- a/tests/e2e/mocked/header-chrome.spec.ts
+++ b/tests/e2e/mocked/header-chrome.spec.ts
@@ -2,6 +2,20 @@ import { test, expect } from '@playwright/test'
 import { authenticate, installApiMocks } from './fixtures'
 
 /**
+ * A colour the browser will not paint, however it chose to serialise it.
+ *
+ * Chromium computes `solid transparent` to `rgba(0, 0, 0, 0)`, so comparing
+ * against that one string does work here -- but the string is a serialisation
+ * detail and the question being asked is about alpha. Reading the alpha says
+ * that, and keeps saying it if the serialisation ever differs.
+ */
+const invisible = (colour: string) => {
+  if (colour === 'transparent') return true
+  const parts = colour.match(/[\d.]+/g)
+  return parts?.length === 4 && Number(parts[3]) === 0
+}
+
+/**
  * The page header, which is two elements in two files.
  *
  * The navbar covers the main column and the sidebar's logo block covers the
@@ -34,7 +48,7 @@ test.describe('the page header', () => {
     // The rail may draw no rule at all (the dark rail sets it transparent, and
     // the colour change between the two surfaces is the divider there). What it
     // must not be is a *different* visible colour from the navbar's.
-    if (seam.logo.colour !== 'rgba(0, 0, 0, 0)') {
+    if (!invisible(seam.logo.colour)) {
       expect(seam.logo.colour, 'both halves use the same rule colour').toBe(seam.navbar.colour)
     }
   })

--- a/tests/e2e/mocked/header-chrome.spec.ts
+++ b/tests/e2e/mocked/header-chrome.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test'
+import { authenticate, installApiMocks } from './fixtures'
+
+/**
+ * The page header, which is two elements in two files.
+ *
+ * The navbar covers the main column and the sidebar's logo block covers the
+ * rail, so the line under them only reads as one line if both are the same
+ * height. They were 50px and 64px, drawn 14px apart, and nothing noticed --
+ * every other test asks whether an element is present, not where its bottom
+ * edge lands.
+ */
+test.describe('the page header', () => {
+  test.beforeEach(async({ page, context }) => {
+    await authenticate(context)
+    await installApiMocks(page)
+    await page.setViewportSize({ width: 1280, height: 800 })
+    await page.goto('/#/admin/sys-oper-log')
+    await page.waitForSelector('.el-tabs__item')
+    await page.waitForTimeout(600)
+  })
+
+  test('its two halves end on the same line', async({ page }) => {
+    const seam = await page.evaluate(() => {
+      const edge = (selector: string) => {
+        const el = document.querySelector(selector) as HTMLElement
+        return { bottom: el.getBoundingClientRect().bottom, colour: getComputedStyle(el).borderBottomColor }
+      }
+      return { logo: edge('.sidebar-logo-container'), navbar: edge('.navbar') }
+    })
+
+    expect(seam.logo.bottom, `logo block ends at ${seam.logo.bottom}, navbar at ${seam.navbar.bottom}`)
+      .toBeCloseTo(seam.navbar.bottom, 0)
+    // The rail may draw no rule at all (the dark rail sets it transparent, and
+    // the colour change between the two surfaces is the divider there). What it
+    // must not be is a *different* visible colour from the navbar's.
+    if (seam.logo.colour !== 'rgba(0, 0, 0, 0)') {
+      expect(seam.logo.colour, 'both halves use the same rule colour').toBe(seam.navbar.colour)
+    }
+  })
+
+  /**
+   * The logo survived collapsing only until Tailwind was added.
+   *
+   * `collapse` is one of its utility names, and v4 generates utilities from the
+   * words it finds in the source -- so writing `:class="{'collapse': ...}"` on
+   * this block is what made it emit `.collapse{visibility:collapse}`. Nothing
+   * here sets visibility, so that rule ran unopposed and hid the whole block.
+   *
+   * It stayed laid out while hidden, which is why this measures a hit test
+   * rather than a box: getBoundingClientRect reported the logo at its usual
+   * 28x28 the entire time it was invisible.
+   */
+  test('the logo is still on screen once the rail collapses', async({ page }) => {
+    await page.locator('.hamburger-container').first().click()
+    await page.waitForTimeout(700)
+
+    const state = await page.evaluate(() => {
+      const box = document.querySelector('.sidebar-logo-container') as HTMLElement
+      const rect = box.getBoundingClientRect()
+      const hit = document.elementFromPoint(rect.x + rect.width / 2, rect.y + rect.height / 2)
+      return {
+        visibility: getComputedStyle(box).visibility,
+        // The element under the middle of the block: its own content when the
+        // block paints, an ancestor when it does not.
+        hitIsInside: !!hit && box.contains(hit),
+        hit: hit ? `${hit.tagName.toLowerCase()}.${(hit.className || '').toString().split(' ')[0]}` : 'null'
+      }
+    })
+
+    expect(state.visibility, 'the block is not hidden by a utility class').toBe('visible')
+    expect(state.hitIsInside, `centre of the block hit ${state.hit}`).toBe(true)
+  })
+})


### PR DESCRIPTION
两个页头缺陷，一个是 bug，一个是对齐。

## 一、侧边栏收起后 logo 消失

图片、首字母、整块全都不见，只剩一个空盒子。

**不是样式漏写**。这块的 `getBoundingClientRect` 全程报 28x28，图片 `complete=true`、`opacity=1`——一切正常，就是画不出来。真正暴露它的是命中测试：在这块正中间取 `elementFromPoint`，拿到的是**祖先元素**而不是图片。

根因是一次类名撞车：

```
div.sidebar-logo-container.collapse   visibility=collapse   ← 元凶
a.sidebar-logo-link                   visibility=collapse   （继承）
img.sidebar-logo                      visibility=collapse   （继承）
```

这块切换的类叫 `collapse`，而 `collapse` **也是 Tailwind 的一个 utility 名**。Tailwind v4 按需生成 utility——它扫描源码里出现的词，于是 `:class="{'collapse': collapse}"` 这一行**自己把 `.collapse{visibility:collapse}` 点了出来**，注入 utilities 层。这个文件没有任何规则设 visibility，那条规则因此毫无对手。

`visibility: collapse` 在非表格元素上等同 `hidden`，但**保留布局**——所以尺寸照常、位置照常，只是不画。这就是它看起来像"样式没写"而不是"元素被藏了"的原因。

改名为 `is-collapsed`。

顺带查了一下 Tailwind 实际生成了什么（从运行时样式表 dump）：

```
collapse invisible visible absolute fixed relative static sticky container
m-8 m-10 m-512 block contents flex grid hidden inline inline-block table
flex-shrink grow transform resize flex-wrap border text-center text-sm
uppercase ordinal shadow outline blur filter transition ease-in-out
```

`m-512` 这种一看就是从某个字符串里扫出来的。**这批里没有一个是我们主动在用的 utility**——全是被源码里的词"点"出来的。详见下面的遗留说明。

## 二、页头那条缝没对齐，颜色也不统一

navbar 高 50px，侧边栏 logo 块高 64px，两条规则**差 14px**。而且 navbar 底下还压着一条 2px 的品牌色渐变，只覆盖主栏。

两件事其实是一件：**对齐之后颜色断裂反而更刺眼**——同一条水平线上，左边是几乎看不见的浅灰，右边是明显的蓝色粗条。

改法：

1. 两半都读 `--ga-header-h`，对齐从"两个文件碰巧写了同一个数"变成结构性的；侧边栏滚动区也减同一个 token，菜单照旧贴在 logo 下面
2. **去掉那条蓝线**。理由三条：它只覆盖主栏，是半条线；它落在标签栏自身上边框往上 2px，两条水平线挤在一起——**上次那个"标签上边框不见了"的缺陷被误读两次，正是因为它看起来像盖住了边框**；分隔这件事 1px 边框已经做到了，而蓝色是这个界面饱和度最高的颜色，更该留给可点的东西

深色侧边栏（`rail-dark`）下 logo 块仍然不画线——深色块与白色主栏之间，颜色变化本身就是分隔。测试对这种情况放行。

## 测试

新增 `header-chrome.spec.ts` 两条，和 `tags-view-chrome.spec.ts` 一个路子——量渲染出来的几何，不量声明值：

- 页头两半的底边落在同一条线上，且可见的规则颜色一致
- 收起后 logo 仍在屏幕上：`visibility` 不被 utility 改掉，**且这块正中的命中测试落在它自己内部**

第二条特意测命中而不是盒子，因为盒子在整个失效期间都是正常的。

**反证**（各自只红对应那条，互不耦合）：

| 退化 | 变红的 |
|---|---|
| 类名改回 `collapse` | logo 那条（`the block is not hidden by a utility class`） |
| logo 块高度改回 64px | 对齐那条（`logo block ends at 64, navbar at 50`） |

## 验证

`lint` 0 error、`type-check`、单测 330 全绿、`pnpm e2e` 255 条全绿（新增 2 条）。

## 遗留（不在本 PR 处理）

Tailwind v4 从源码文本按需生成 utility，这意味着**任何与 utility 同名的自有类名都可能被注入样式**，而且只在"我们自己没设那个属性"时才发作——静默、难查。这次是 `collapse`，生成清单里还有 `container`、`hidden`、`block`、`flex`、`border`、`shadow` 等常见词。

根治方向是给 Tailwind 配 prefix，或收窄 `@source` 扫描范围，让它不再从 SFC 的类名里发明 utility。这需要先确认项目实际用了哪些 utility，是独立的一件事。
