### PR TITLE
chore(build): 给 Tailwind utility 加 tw: 前缀，根除与自有类名撞车

### DIFF
--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -18,8 +18,8 @@
 
 @layer theme, base, components, utilities;
 
-@import "tailwindcss/theme.css" layer(theme);
-@import "tailwindcss/utilities.css" layer(utilities);
+@import "tailwindcss/theme.css" layer(theme) prefix(tw);
+@import "tailwindcss/utilities.css" layer(utilities) prefix(tw);
 
 /*
  * Map Tailwind's theme onto the design tokens so `bg-brand` and an Element Plus

--- a/tests/unit/build/tailwind-prefix.spec.ts
+++ b/tests/unit/build/tailwind-prefix.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { compile } from 'tailwindcss'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+
+/**
+ * Tailwind's utilities must not answer to the class names this app writes.
+ *
+ * v4 generates utilities on demand from whatever words it finds while scanning
+ * source, so a class of our own that happens to share a utility name gets one
+ * generated for it. That rule then applies to our element -- and wins for any
+ * property our own stylesheet does not set, because nothing is competing.
+ *
+ * That is not hypothetical. The sidebar toggles a class called `collapse` on
+ * its logo block, which made Tailwind emit `.collapse{visibility:collapse}`;
+ * nothing in that component sets visibility, so the whole logo disappeared the
+ * moment the rail collapsed, while still reporting its usual size and position.
+ *
+ * `prefix(tw)` closes it structurally: utilities answer only to `tw:` names, so
+ * no class we write can reach them by accident.
+ *
+ * Compiled here rather than asserted as text, because what matters is what
+ * Tailwind emits, not how the entry point is spelled.
+ */
+const compileWith = async(candidates: string[]) => {
+  const entry = resolve(__dirname, '../../../src/styles/tailwind.css')
+  const compiler = await compile(readFileSync(entry, 'utf8'), {
+    base: dirname(entry),
+    loadStylesheet: async(id: string, base: string) => {
+      const path = id.startsWith('tailwindcss')
+        ? resolve(__dirname, '../../../node_modules', id)
+        : resolve(base, id)
+      return { path, base: dirname(path), content: readFileSync(path, 'utf8') }
+    }
+  })
+  return compiler.build(candidates)
+}
+
+/** Rules inside `@layer utilities { ... }`, which is where generated ones land. */
+const utilityRules = (css: string) => {
+  const start = css.indexOf('@layer utilities {')
+  return start < 0 ? '' : css.slice(start)
+}
+
+describe('tailwind utilities are namespaced', () => {
+  /**
+   * Every one of these is a real class in src/, and each was generating a
+   * utility of the same name before the prefix: `collapse` hid the sidebar
+   * logo, and the rest were saved only by their own stylesheet happening to
+   * set the same property Tailwind would have.
+   */
+  it('generates nothing for the class names this app already uses', async() => {
+    const css = await compileWith([
+      'collapse', 'hidden', 'block', 'border', 'shadow', 'text-center', 'text-sm',
+      'container', 'flex', 'grid', 'fixed', 'absolute', 'visible', 'invisible'
+    ])
+
+    expect(utilityRules(css), `unexpected utilities:\n${utilityRules(css)}`).toBe('')
+  })
+
+  /**
+   * The other half: a prefix that generated nothing at all would pass the check
+   * above by breaking Tailwind rather than by namespacing it.
+   */
+  it('still generates them under the tw: prefix', async() => {
+    const css = await compileWith(['tw:flex', 'tw:text-center'])
+
+    expect(css).toContain('display: flex')
+    expect(css).toContain('text-align: center')
+  })
+})

--- a/tests/unit/build/tailwind-prefix.spec.ts
+++ b/tests/unit/build/tailwind-prefix.spec.ts
@@ -22,13 +22,16 @@ import { dirname, resolve } from 'node:path'
  * Compiled here rather than asserted as text, because what matters is what
  * Tailwind emits, not how the entry point is spelled.
  */
+// import.meta.dirname, matching tests/unit/scripts/sync-apps.spec.js: vitest
+// resolves its own aliases that way and does not promise this module's
+// import.meta.url is a real file:// URL.
 const compileWith = async(candidates: string[]) => {
-  const entry = resolve(__dirname, '../../../src/styles/tailwind.css')
+  const entry = resolve(import.meta.dirname, '../../../src/styles/tailwind.css')
   const compiler = await compile(readFileSync(entry, 'utf8'), {
     base: dirname(entry),
     loadStylesheet: async(id: string, base: string) => {
       const path = id.startsWith('tailwindcss')
-        ? resolve(__dirname, '../../../node_modules', id)
+        ? resolve(import.meta.dirname, '../../../node_modules', id)
         : resolve(base, id)
       return { path, base: dirname(path), content: readFileSync(path, 'utf8') }
     }
@@ -36,10 +39,28 @@ const compileWith = async(candidates: string[]) => {
   return compiler.build(candidates)
 }
 
-/** Rules inside `@layer utilities { ... }`, which is where generated ones land. */
+/**
+ * What is inside `@layer utilities { ... }`, which is where generated rules
+ * land. Empty string when the layer holds nothing or is not emitted at all --
+ * Tailwind writes a bare `@layer utilities;` in that case, and the two should
+ * read the same to the assertion below.
+ *
+ * Brace-matched rather than sliced to the end of the file: a slice reports
+ * every later layer as though it were a utility, which turns one unexpected
+ * rule into an unreadable failure message.
+ */
 const utilityRules = (css: string) => {
   const start = css.indexOf('@layer utilities {')
-  return start < 0 ? '' : css.slice(start)
+  if (start < 0) return ''
+
+  let depth = 0
+  for (let i = css.indexOf('{', start); i < css.length; i++) {
+    if (css[i] === '{') depth++
+    else if (css[i] === '}' && --depth === 0) {
+      return css.slice(css.indexOf('{', start) + 1, i).trim()
+    }
+  }
+  return css.slice(start).trim()
 }
 
 describe('tailwind utilities are namespaced', () => {


### PR DESCRIPTION
接 #299。那个 PR 修掉了侧边栏 logo 被 `.collapse` 隐藏的问题，但只改了一个类名——同类隐患还在。这个 PR 从机制上关掉它。

## 隐患是什么

Tailwind v4 **按需生成** utility：它扫描源码文本，看到哪个词就生成哪个规则。所以我们自己写的类名会**把同名 utility 点出来**，那条规则随后作用在我们的元素上，并且**在我们自己没设那个属性时毫无对手**。

`#299` 那个 bug 就是这么来的：`:class="{'collapse': collapse}"` → Tailwind 生成 `.collapse{visibility:collapse}` → 组件里没有任何规则设 visibility → 整块 logo 消失，而尺寸位置一切正常。

## 排查：到底有多少

把运行时实际生成的 36 个 utility 拿出来，和源码里真正用作 class 的名字、以及项目自己定义的类做三方交叉：

| 情况 | 数量 | 说明 |
|---|---|---|
| 纯误扫，没有任何元素用它 | **30** | 含 `m-512`（从某个字符串里扫出来的）、`invisible`、`sticky`、`ordinal`… |
| 撞名，项目自有类 | 5 | `.hidden` `.block` `.border` `.shadow` `.text-center` |
| 看起来真在用 | 1 | `.text-sm` |

那 5 个撞名的，逐个查下来都**只是碰巧没出事**：

| 类 | 项目自己设的 | Tailwind 想补的 | 为什么没炸 |
|---|---|---|---|
| `.hidden` | `display:none` | `display:none` | 恰好一样 |
| `.block` | 无定义 | `display:block` | div 本来就是 block |
| `.border` | `::after` 画线 | `border-width:1px` | 没有 `border-style`，不画 |
| `.shadow` | SVG 动画 | `box-shadow` | SVG 元素不生成 CSS box |

**没有一个是设计好的，全靠巧合。** 下一个写 `flex`、`grid`、`fixed` 的人就没这个运气了。

而 36 个里**没有一个是我们主动写的 Tailwind 用法**——`@theme inline` 那套 `bg-brand` 映射也一次都没被用到。

## 改法

```css
@import "tailwindcss/theme.css" layer(theme) prefix(tw);
@import "tailwindcss/utilities.css" layer(utilities) prefix(tw);
```

utility 只认 `tw:` 开头的名字，我们写的任何类名都不可能再碰到它们。这是结构性的，不是逐个改类名。

加完之后，构建产物里的 utilities 层是**空的**——这也如实反映了这个项目目前用了多少 Tailwind。要用的时候 `tw:flex` 照常工作。

## 一处渲染变化

`profile/components/Activity.vue` 里两个 `<span class="link-black text-sm">` 失去了 14px 字号。

项目**从未定义过** `.text-sm`（`git log -S` 在 scss/css 里查不到任何提交），所以它在 Tailwind 于 `3e86c46`(8/17) 引入之前就是死类名，现在回到死类名——是撤销一次意外，不是破坏。那段还是 vue-element-admin 的演示数据（"Charlie Sheen fans"、Share/Like）。

## 测试

`tests/unit/build/tailwind-prefix.spec.ts`，编译入口而不是读它的文本——重要的是 Tailwind 吐出什么，不是配置怎么拼写。两条：

1. 喂进项目里真实存在的类名（`collapse` `hidden` `block` `border` `shadow` `text-center` `flex` `grid` `fixed`…），utilities 层必须是空的
2. 喂进 `tw:flex` / `tw:text-center`，必须照常生成

第二条是必要的另一半：一个把 Tailwind 整个弄坏的改动，只看第一条也会通过。

**反证**：去掉两处 `prefix(tw)`，第一条如期变红，失败信息直接打出元凶：

```
unexpected utilities:
@layer utilities {
  .collapse {
    visibility: collapse;
```

## 验证

`lint` 0 error、`type-check`、单测 332 全绿（新增 2 条）、`pnpm e2e` 255 条全绿。
