### PR TITLE
test(protable): 移动端卡片列表改用滚动触发，修掉 click 与自动加载互相追逐导致的间歇失败

### DIFF
--- a/tests/e2e/mocked/protable-mobile-ui.spec.ts
+++ b/tests/e2e/mocked/protable-mobile-ui.spec.ts
@@ -41,6 +41,23 @@ async function installPagedUsers(page: Page, total = 25) {
   return calls
 }
 
+/**
+ * Reaches the end of the list, which is how this component loads more.
+ *
+ * Not a click on the button inside the sentinel, even though that button works:
+ * Playwright scrolls a target into view before clicking, that scroll is what
+ * brings the sentinel into view, and the load it triggers re-creates the
+ * sentinel (`v-if="hasMore || loading"`) -- so the button detaches mid-click and
+ * Playwright retries, scrolls, and detaches it again until the test times out.
+ * Once in fifty runs it lost that race; the click never lands.
+ *
+ * Scrolling drives the IntersectionObserver directly, which is the path a
+ * reader takes and the one the component was built around.
+ */
+const scrollToEnd = async(page: Page) => {
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
+}
+
 const openList = async(page: Page) => {
   await page.goto('/#/admin/sys-user')
   await expect(page.locator('.pro-card').first()).toBeVisible({ timeout: 15000 })
@@ -140,6 +157,16 @@ test.describe('the phone layout', () => {
   })
 })
 
+/**
+ * Reaching the end loads more than one page, on purpose.
+ *
+ * The sentinel stays on screen while each page lands, so the observer fires
+ * again -- which is what an infinite list is supposed to do once you are at the
+ * bottom of it. So these assert the property each test is named for (appended
+ * rather than replaced, cards left open, the list started over) and not a page
+ * count: pinning the count reported 25 cards where 20 were expected, which
+ * reads as a defect in the component and is not one.
+ */
 test.describe('loading more by scrolling', () => {
   test.beforeEach(async({ page, context }) => {
     await authenticate(context)
@@ -155,14 +182,18 @@ test.describe('loading more by scrolling', () => {
     await expect(cards).toHaveCount(10)
     await expect(page.locator('.pro-card__title').first()).toHaveText('user1')
 
-    await page.locator('.pro-cards__more button').click()
+    await scrollToEnd(page)
+    await expect.poll(() => cards.count()).toBeGreaterThan(10)
 
-    // 20, not 10: replacing would leave the count unchanged and the first title
-    // reading user11 -- which is exactly what a pager does, and the bug this
-    // guards against.
-    await expect(cards).toHaveCount(20)
+    // Replacing would hold the count at ten and leave the first title reading
+    // user11 -- which is what a pager does, and the bug this guards against.
     await expect(page.locator('.pro-card__title').first()).toHaveText('user1')
-    expect(calls.pages).toEqual([1, 2])
+    // Ascending with no repeats: each page asked for once, in order. A stack
+    // that reset itself would ask for page one again partway through.
+    expect(calls.pages[0]).toBe(1)
+    expect(calls.pages).toContain(2)
+    expect(calls.pages, `pages: ${calls.pages}`).toEqual([...calls.pages].sort((a, b) => a - b))
+    expect(new Set(calls.pages).size, `pages: ${calls.pages}`).toBe(calls.pages.length)
   })
 
   test('a card stays open when the next page arrives', async({ page }) => {
@@ -173,8 +204,8 @@ test.describe('loading more by scrolling', () => {
     await first.locator('.pro-card__toggle').click()
     await expect(first.locator('.pro-card__toggle')).toHaveText('收起')
 
-    await page.locator('.pro-cards__more button').click()
-    await expect(page.locator('.pro-card')).toHaveCount(20)
+    await scrollToEnd(page)
+    await expect.poll(() => page.locator('.pro-card').count()).toBeGreaterThan(10)
 
     // The reset watches the row count rather than the array: appending leaves
     // the rows already on screen unchanged, and closing them would punish
@@ -186,7 +217,7 @@ test.describe('loading more by scrolling', () => {
     await installPagedUsers(page, 12)
     await openList(page)
 
-    await page.locator('.pro-cards__more button').click()
+    await scrollToEnd(page)
     await expect(page.locator('.pro-card')).toHaveCount(12)
 
     // The sentinel has to disappear, or it keeps asking for a page that is not
@@ -196,19 +227,30 @@ test.describe('loading more by scrolling', () => {
   })
 
   test('a new search starts the list over', async({ page }) => {
-    await installPagedUsers(page, 25)
+    const calls = await installPagedUsers(page, 25)
     await openList(page)
-    await page.locator('.pro-cards__more button').click()
-    await expect(page.locator('.pro-card')).toHaveCount(20)
+    await scrollToEnd(page)
+    await expect.poll(() => page.locator('.pro-card').count()).toBeGreaterThan(10)
 
+    const beforeSearch = calls.pages.length
     await page.locator('.pro-table__filter-bar button').click()
     const sheet = page.locator('.el-drawer.pro-table__sheet')
     await sheet.locator('input[placeholder="请输入用户名称"]').fill('user')
     await sheet.getByRole('button', { name: '查看结果' }).click()
 
-    // Page one is also the signal that the stack is stale; without it the new
-    // results would be appended below the old ones.
+    await expect.poll(() => calls.pages.length).toBeGreaterThan(beforeSearch)
+    expect(calls.pages[beforeSearch], `pages: ${calls.pages}`).toBe(1)
+
+    // Back to the top before counting: at the end of the list the sentinel is
+    // on screen and keeps loading, and this test is asking whether the list
+    // started over, not how much of it can be loaded. Away from the sentinel
+    // the count settles and can be pinned exactly -- which is the assertion
+    // that fails if the stack appends the new results below the old ones.
+    // Requesting page one is not enough on its own: the query resets whether
+    // or not the stack does, so a request-level check passes either way.
+    await page.evaluate(() => window.scrollTo(0, 0))
     await expect(page.locator('.pro-card')).toHaveCount(10)
+    await expect(page.locator('.pro-card__title').first()).toHaveText('user1')
   })
 })
 

--- a/tests/e2e/mocked/protable-mobile-ui.spec.ts
+++ b/tests/e2e/mocked/protable-mobile-ui.spec.ts
@@ -227,10 +227,21 @@ test.describe('loading more by scrolling', () => {
   })
 
   test('a new search starts the list over', async({ page }) => {
-    const calls = await installPagedUsers(page, 25)
+    // Two pages, so one scroll reaches the end of the list: scrollTo goes to
+    // the bottom as it stands, and a page landing makes the document taller
+    // than that, which leaves the sentinel below the fold again. Twenty rows
+    // is the size that makes "the list has run out" a state this test can wait
+    // for rather than approach.
+    const calls = await installPagedUsers(page, 20)
     await openList(page)
     await scrollToEnd(page)
-    await expect.poll(() => page.locator('.pro-card').count()).toBeGreaterThan(10)
+
+    // Snapshot the call log only once nothing else can add to it. Taken while a
+    // page is still in flight, that page lands after the snapshot and takes the
+    // slot the search's own request is checked in -- failing the assertion
+    // below for a reason that has nothing to do with searching.
+    await expect(page.locator('.pro-cards__more')).toHaveCount(0)
+    await expect(page.locator('.pro-card')).toHaveCount(20)
 
     const beforeSearch = calls.pages.length
     await page.locator('.pro-table__filter-bar button').click()


### PR DESCRIPTION
`protable-mobile-ui.spec.ts` 里"滚动加载"那组，本轮开发中间歇性红过两次（不同的用例，都是单跑就绿）。这个 PR 定位并修掉它。

## 不是我一开始以为的那个原因

组件注释说"第一页十张卡片超出折叠线约 90px"，所以第一反应是余量太小、sentinel 偶尔落进视口触发自动加载。**实测余量是 416px**，sentinel 稳稳在视口外，这条排除。

重复跑 60 次复现出 1 次，失败信息给出了真相：

```
- scrolling into view if needed
- done scrolling
- element was detached from the DOM, retrying
```

Playwright 在点击前会把目标滚进视口，而被点的按钮**就在 IntersectionObserver 观察的那个元素里**：

1. 滚动使 sentinel 进入视口
2. observer 触发 `loadMore`
3. 数据到达，`hasMore`/`loading` 变化让 sentinel（`v-if="hasMore || loading"`）销毁重建
4. 按钮从 DOM 分离，click 失败重试
5. 重试又要滚动 → 回到第 1 步

**click 和自动加载在互相追逐**，直到 30 秒超时。两种失败形态（"25 张卡片而非 20 张"、"按钮点不到"）是同一个原因的两个阶段。

## 改法

不点那个按钮，改用滚动触发：

```js
await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
```

这是这个组件真正的设计路径——sentinel + IntersectionObserver，按钮只是无 observer 时的兜底。测试因此走的是读者会走的那条路。

到达列表末尾会连续加载多页（sentinel 在每页落地时仍在屏幕上，这是无限列表应有的行为），所以钉死单页的计数断言都去掉了，改为断言每条测试名字所声称的性质。

## 一处我改错了，反证抓出来的

唯一保留精确计数的是"搜索后应剩十张"。第一版我把它换成了"搜索后的第一个请求是第 1 页"，理由是计数不稳定。

**反证时它没红**：把 stack 改成永不重置（新结果叠在旧的下面），这条测试照样通过。因为退化改的是 **stack 层**（前端怎么合并数据），而我的断言测的是**请求层**——`query` 不管 stack 重不重置都会回到第 1 页。

我为了稳定，把这条测试抓 bug 的能力一起换掉了。

修正：搜索后先滚回顶部，让 sentinel 离开视口，计数就稳定了，于是能保留那个位于正确层次的断言。

## 反证（三条都真红过）

| 退化 | 变红的 |
|---|---|
| stack 总是替换（退化成分页器） | 4 条全红 |
| stack 永不重置 | 「搜索重新开始」红在 `toHaveCount(10)` |
| 去掉「追加时不重置展开态」的守卫 | 「保持展开」红在 `收起` |

## 验证

`protable-mobile-ui.spec.ts` 全组 **270 次连续全绿**（改动前：60 次红 1 次、100 次红 2 次）。

`lint` 0 error、全量 `pnpm e2e` 255 条全绿。
